### PR TITLE
chore: changelog history notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## [3.2.6]
 
-This package was previously published as `@dfinity/auth-client` and its source code was hosted at `https://github.com/dfinity/icp-js-core`. The [CHANGELOG](https://github.com/dfinity/icp-js-core/blob/a6aa6e2eb58cf2cbae92156b957293e40f458323/CHANGELOG.md) of that repository contains the history of the changes up until v3.
+This package was previously published as `@dfinity/auth-client` and its source code was hosted at [dfinity/icp-js-core](https://github.com/dfinity/icp-js-core). The [CHANGELOG](https://github.com/dfinity/icp-js-core/blob/a6aa6e2eb58cf2cbae92156b957293e40f458323/CHANGELOG.md) of that repository contains the history of the changes up until v3.


### PR DESCRIPTION
Add a notice in the changelog on where to find the old changelog. The [3.2.6](https://github.com/dfinity/icp-js-auth/tree/3.2.6) tag has been published to commitizen work properly.
