### PR TITLE
chore: disable pnpm root workspace checks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-workspace-root-check=true


### PR DESCRIPTION
Before adding this flag, pnpm was failing when installing the package in the root of the workspace.
