### PR TITLE
docs(auth): correct idleTimeout default in docs to 10 minutes

### DIFF
--- a/src/client/idle-manager.ts
+++ b/src/client/idle-manager.ts
@@ -7,7 +7,7 @@ export type IdleManagerOptions = {
   onIdle?: IdleCB;
   /**
    * timeout in ms
-   * @default 30 minutes [600_000]
+   * @default 10 minutes [600_000]
    */
   idleTimeout?: number;
   /**


### PR DESCRIPTION
# Motivation

There is a typo in the default value of `idleTimeout` in the function's documentation. As shown [here](https://github.com/dfinity/icp-js-auth/blob/2a6f2a5c5e48d315288de74aee0e120bdeeb8382/src/client/idle-manager.ts#L34), it should be 10 minutes instead of 30 minutes.