### PR TITLE
feat: one-click OpenID sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ try {
 await authClient.logout();
 ```
 
+### One-Click OpenID Sign-In
+
+Skip the Internet Identity authentication method screen and offer sign-in options like Google directly in your app:
+
+```typescript
+const authClient = new AuthClient({
+  openIdProvider: 'google', // or 'apple' or 'microsoft'
+});
+
+await authClient.login();
+```
+
 Additional documentation can be found [here](https://js.icp.build/auth/latest/).
 
 ## Contributing

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -172,7 +172,9 @@ export class AuthClient {
     this.#options = options;
     this.#storage = options.storage ?? new IdbStorage();
 
-    const identityProviderUrl = new URL(options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT);
+    const identityProviderUrl = new URL(
+      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
+    );
     if (options.openIdProvider) {
       identityProviderUrl.searchParams.set('openid', OPENID_PROVIDER_URLS[options.openIdProvider]);
     }

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -35,6 +35,8 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
+export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
+
 const OPENID_PROVIDER_URLS: Record<OpenIdProvider, string> = {
   google: 'https://accounts.google.com',
   apple: 'https://appleid.apple.com',
@@ -97,8 +99,6 @@ export interface AuthClientCreateOptions {
    */
   openIdProvider?: OpenIdProvider;
 }
-
-export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
 
 export interface IdleOptions extends IdleManagerOptions {
   /**

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -35,6 +35,12 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
+const OPENID_PROVIDER_URLS: Record<OpenIdProvider, string> = {
+  google: 'https://accounts.google.com',
+  apple: 'https://appleid.apple.com',
+  microsoft: 'https://login.microsoftonline.com/{tid}/v2.0',
+};
+
 export const ERROR_USER_INTERRUPT = 'UserInterrupt';
 
 /**
@@ -83,7 +89,16 @@ export interface AuthClientCreateOptions {
    * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
    */
   windowOpenerFeatures?: string;
+
+  /**
+   * OpenID provider for one-click sign-in. When set, the identity provider
+   * URL includes an `openid` search param so the user authenticates via
+   * the chosen provider (e.g. Google) instead of seeing Internet Identity directly.
+   */
+  openIdProvider?: OpenIdProvider;
 }
+
+export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
 
 export interface IdleOptions extends IdleManagerOptions {
   /**
@@ -157,10 +172,13 @@ export class AuthClient {
     this.#options = options;
     this.#storage = options.storage ?? new IdbStorage();
 
-    const identityProviderUrl = options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
+    const identityProviderUrl = new URL(options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT);
+    if (options.openIdProvider) {
+      identityProviderUrl.searchParams.set('openid', OPENID_PROVIDER_URLS[options.openIdProvider]);
+    }
 
     const transport = new PostMessageTransport({
-      url: identityProviderUrl,
+      url: identityProviderUrl.toString(),
       windowOpenerFeatures: options.windowOpenerFeatures,
     });
 

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -11,11 +11,14 @@ import {
 } from '../../src/client/storage.ts';
 
 // Mock @icp-sdk/signer so login() doesn't open real windows.
-const mockSignerInstance = {
-  openChannel: vi.fn(),
-  closeChannel: vi.fn(),
-  requestDelegation: vi.fn(),
-};
+const { mockSignerInstance, mockPostMessageTransport } = vi.hoisted(() => ({
+  mockSignerInstance: {
+    openChannel: vi.fn(),
+    closeChannel: vi.fn(),
+    requestDelegation: vi.fn(),
+  },
+  mockPostMessageTransport: vi.fn(),
+}));
 
 vi.mock('@icp-sdk/signer', () => ({
   Signer: class {
@@ -26,7 +29,7 @@ vi.mock('@icp-sdk/signer', () => ({
 }));
 
 vi.mock('@icp-sdk/signer/web', () => ({
-  PostMessageTransport: vi.fn(),
+  PostMessageTransport: mockPostMessageTransport,
 }));
 
 /**
@@ -106,6 +109,24 @@ describe('AuthClient', () => {
     const client = new AuthClient();
     await client.getIdentity(); // wait for hydration
     expect(client.idleManager).toBeUndefined();
+  });
+
+  it.each([
+    ['google', 'https://accounts.google.com'],
+    ['apple', 'https://appleid.apple.com'],
+    ['microsoft', 'https://login.microsoftonline.com/{tid}/v2.0'],
+  ] as const)('should pass openid=%s search param to the transport', (provider, expectedUrl) => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({ openIdProvider: provider });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.get('openid')).toBe(expectedUrl);
+  });
+
+  it('should not include openid search param when openIdProvider is not set', () => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient();
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.has('openid')).toBe(false);
   });
 
   it('should not set up an idle timer if the disable option is set', () => {

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -213,7 +213,7 @@ describe('AuthClient login', () => {
 
   it('should set the localStorage expiration flag after login', async () => {
     await mockSignerForLogin();
-    const client = new AuthClient();
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     expect(client.isAuthenticated()).toBe(false);
     await client.login();
     expect(client.isAuthenticated()).toBe(true);
@@ -221,7 +221,7 @@ describe('AuthClient login', () => {
 
   it('should clear the localStorage expiration flag on logout', async () => {
     await mockSignerForLogin();
-    const client = new AuthClient();
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     await client.login();
     expect(client.isAuthenticated()).toBe(true);
     await client.logout();


### PR DESCRIPTION
Adds support for one-click sign-in via OpenID providers. When `openIdProvider` is set on `AuthClientCreateOptions`, the identity provider URL includes an `openid` search param, allowing the user to authenticate via Google, Apple, or Microsoft instead of seeing Internet Identity directly.

Supported providers:
- `'google'` → `https://accounts.google.com`
- `'apple'` → `https://appleid.apple.com`
- `'microsoft'` → `https://login.microsoftonline.com/{tid}/v2.0`

```typescript
const authClient = new AuthClient({
  openIdProvider: 'google',
});
await authClient.login();
```