### PR TITLE
refactor: sync constructor, sync isAuthenticated, async getIdentity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,24 @@ Here's a simple example of how to use the `@icp-sdk/auth` package to authenticat
 ```typescript
 import { AuthClient } from '@icp-sdk/auth/client';
 
-const identityProvider = 'https://id.ai/';
+const authClient = new AuthClient();
 
-const authClient = await AuthClient.create();
-const identity = authClient.getIdentity(); // At this point, you'll get a Principal.anonymous()
-
-async function onSuccess() {
-  console.log('Login successful');
-
-  const identity = authClient.getIdentity(); // At this point, you'll get an authenticated identity
-  console.log(authClient.isAuthenticated()); // true
+// Check for an existing session (synchronous)
+if (authClient.isAuthenticated()) {
+  const identity = await authClient.getIdentity();
+  console.log('Restored session:', identity.getPrincipal().toString());
 }
 
-await authClient.login({
-  identityProvider,
-  onSuccess,
-});
+// Log in
+try {
+  await authClient.login();
+  const identity = await authClient.getIdentity();
+  console.log('Logged in:', identity.getPrincipal().toString());
+} catch (error) {
+  console.error('Login failed:', error);
+}
 
-// later in your app
+// Log out
 await authClient.logout();
 ```
 

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -16,35 +16,35 @@ import { HttpAgent } from '@icp-sdk/core/agent';
 const network = 'ic'; // typically, this value is read from the environment (e.g. process.env.DFX_NETWORK)
 const identityProvider =
   network === 'ic'
-    ? 'https://id.ai/' // Mainnet
+    ? 'https://id.ai/authorize' // Mainnet
     : 'http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:4943'; // Local
 
-const authClient = await AuthClient.create();
-const identity = authClient.getIdentity(); // At this point, you'll get a Principal.anonymous()
-console.log(authClient.isAuthenticated()); // false
+const authClient = new AuthClient({ identityProvider });
+
+// Check for an existing session (synchronous)
+if (authClient.isAuthenticated()) {
+  const identity = await authClient.getIdentity();
+  console.log('Restored session:', identity.getPrincipal().toString());
+}
 
 const canisterId = Principal.fromText('uqqxf-5h777-77774-qaaaa-cai');
 const agent = await HttpAgent.create({
   host: 'https://icp-api.io',
 });
 
-async function onSuccess() {
-  console.log('Login successful');
-
-  const identity = authClient.getIdentity(); // At this point, you'll get an authenticated identity
-  console.log(authClient.isAuthenticated()); // true
-  agent.replaceIdentity(identity);
-
-  // this call will be authenticated
-  await agent.call(canisterId, {
-    methodName: 'greet',
-    arg: IDL.encode([IDL.Text], ['world']),
-  });
+try {
+  await authClient.login();
+} catch (error) {
+  console.error('Login failed:', error);
 }
 
-await authClient.login({
-  identityProvider,
-  onSuccess,
+const identity = await authClient.getIdentity();
+agent.replaceIdentity(identity);
+
+// this call will be authenticated
+await agent.call(canisterId, {
+  methodName: 'greet',
+  arg: IDL.encode([IDL.Text], ['world']),
 });
 
 // later in your app

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -38,6 +38,8 @@ const ECDSA_KEY_LABEL = 'ECDSA';
 const ED25519_KEY_LABEL = 'Ed25519';
 type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
+const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
+
 /**
  * List of options for creating an {@link AuthClient}.
  */
@@ -125,323 +127,21 @@ export interface AuthClientLoginOptions {
   onError?: OnErrorFunc;
 }
 
+// ---------------------------------------------------------------------------
+// Free functions – persistence helpers
+// ---------------------------------------------------------------------------
+
 /**
  * Generates a fresh session key of the given type.
  */
-async function generateKey(
-  keyType: BaseKeyType,
-): Promise<SignIdentity> {
+async function generateKey(keyType: BaseKeyType): Promise<SignIdentity> {
   if (keyType === ED25519_KEY_LABEL) {
     return Ed25519KeyIdentity.generate();
   }
   return await ECDSAKeyIdentity.generate();
 }
 
-/**
- * Tool to manage authentication and identity
- * @see {@link AuthClient}
- */
-export class AuthClient {
-  /**
-   * Create an AuthClient to manage authentication and identity
-   * @param {AuthClientCreateOptions} options - Options for creating an {@link AuthClient}
-   * @see {@link AuthClientCreateOptions}
-   * @param options.identity Optional Identity to use as the base
-   * @see {@link SignIdentity}
-   * @param options.storage Storage mechanism for delegation credentials
-   * @see {@link AuthClientStorage}
-   * @param options.keyType Type of key to use for the base key
-   * @param {IdleOptions} options.idleOptions Configures an {@link IdleManager}
-   * @see {@link IdleOptions}
-   * Default behavior is to clear stored identity and reload the page when a user goes idle, unless you set the disableDefaultIdleCallback flag or pass in a custom idle callback.
-   * @example
-   * const authClient = await AuthClient.create({
-   *   idleOptions: {
-   *     disableIdle: true
-   *   }
-   * })
-   */
-  public static async create(options: AuthClientCreateOptions = {}): Promise<AuthClient> {
-    const storage = options.storage ?? new IdbStorage();
-    const keyType = options.keyType ?? ECDSA_KEY_LABEL;
-
-    let key: null | SignIdentity | PartialIdentity = null;
-    if (options.identity) {
-      key = options.identity;
-    } else {
-      let maybeIdentityStorage = await storage.get(KEY_STORAGE_KEY);
-      if (!maybeIdentityStorage) {
-        // Attempt to migrate from localstorage
-        try {
-          const fallbackLocalStorage = new LocalStorage();
-          const localChain = await fallbackLocalStorage.get(KEY_STORAGE_DELEGATION);
-          const localKey = await fallbackLocalStorage.get(KEY_STORAGE_KEY);
-          // not relevant for Ed25519
-          if (localChain && localKey && keyType === ECDSA_KEY_LABEL) {
-            console.log('Discovered an identity stored in localstorage. Migrating to IndexedDB');
-            await storage.set(KEY_STORAGE_DELEGATION, localChain);
-            await storage.set(KEY_STORAGE_KEY, localKey);
-
-            maybeIdentityStorage = localChain;
-            // clean up
-            await fallbackLocalStorage.remove(KEY_STORAGE_DELEGATION);
-            await fallbackLocalStorage.remove(KEY_STORAGE_KEY);
-          }
-        } catch (error) {
-          console.error(`error while attempting to recover localstorage: ${error}`);
-        }
-      }
-      if (maybeIdentityStorage) {
-        try {
-          if (typeof maybeIdentityStorage === 'object') {
-            if (keyType === ED25519_KEY_LABEL && typeof maybeIdentityStorage === 'string') {
-              key = Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
-            } else {
-              key = await ECDSAKeyIdentity.fromKeyPair(maybeIdentityStorage);
-            }
-          } else if (typeof maybeIdentityStorage === 'string') {
-            // This is a legacy identity, which is a serialized Ed25519KeyIdentity.
-            key = Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
-          }
-        } catch {
-          // Ignore this, this means that the localStorage value isn't a valid Ed25519KeyIdentity or ECDSAKeyIdentity
-          // serialization.
-        }
-      }
-    }
-
-    let identity: SignIdentity | PartialIdentity = new AnonymousIdentity() as PartialIdentity;
-    let chain: null | DelegationChain = null;
-    if (key) {
-      try {
-        const chainStorage = await storage.get(KEY_STORAGE_DELEGATION);
-        if (typeof chainStorage === 'object' && chainStorage !== null) {
-          throw new Error(
-            'Delegation chain is incorrectly stored. A delegation chain should be stored as a string.',
-          );
-        }
-
-        if (options.identity) {
-          identity = options.identity;
-        } else if (chainStorage) {
-          chain = DelegationChain.fromJSON(chainStorage);
-
-          // Verify that the delegation isn't expired.
-          if (!isDelegationValid(chain)) {
-            await _deleteStorage(storage);
-            key = null;
-          } else {
-            // If the key is a public key, then we create a PartialDelegationIdentity.
-            if ('toDer' in key) {
-              identity = PartialDelegationIdentity.fromDelegation(key, chain);
-              // otherwise, we create a DelegationIdentity.
-            } else {
-              identity = DelegationIdentity.fromDelegation(key, chain);
-            }
-          }
-        }
-      } catch (e) {
-        console.error(e);
-        // If there was a problem loading the chain, delete the key.
-        await _deleteStorage(storage);
-        key = null;
-      }
-    }
-    let idleManager: IdleManager | undefined;
-    if (options.idleOptions?.disableIdle) {
-      idleManager = undefined;
-    }
-    // if there is a delegation chain or provided identity, setup idleManager
-    else if (chain || options.identity) {
-      idleManager = IdleManager.create(options.idleOptions);
-    }
-
-    if (!key) {
-      // Create a new key (whether or not one was in storage).
-      if (keyType === ED25519_KEY_LABEL) {
-        key = Ed25519KeyIdentity.generate();
-      } else {
-        if (options.storage && keyType === ECDSA_KEY_LABEL) {
-          console.warn(
-            `You are using a custom storage provider that may not support CryptoKey storage. If you are using a custom storage provider that does not support CryptoKey storage, you should use '${ED25519_KEY_LABEL}' as the key type, as it can serialize to a string`,
-          );
-        }
-        key = await ECDSAKeyIdentity.generate();
-      }
-      await persistKey(storage, key);
-    }
-
-    // Create transport and signer from create-time options so they are reusable across logins.
-    const identityProviderUrl =
-      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
-
-    const transport = new PostMessageTransport({
-      url: identityProviderUrl,
-      windowOpenerFeatures: options.windowOpenerFeatures,
-    });
-
-    const signer = new Signer({
-      transport,
-      derivationOrigin: options.derivationOrigin?.toString(),
-    });
-
-    return new AuthClient(identity, key, chain, storage, idleManager, options, signer);
-  }
-
-  protected constructor(
-    private _identity: Identity | PartialIdentity,
-    private _key: SignIdentity | PartialIdentity,
-    private _chain: DelegationChain | null,
-    private _storage: AuthClientStorage,
-    public idleManager: IdleManager | undefined,
-    private _createOptions: AuthClientCreateOptions | undefined,
-    private _signer: Signer,
-  ) {
-    this._registerDefaultIdleCallback();
-  }
-
-  private _registerDefaultIdleCallback() {
-    const idleOptions = this._createOptions?.idleOptions;
-    /**
-     * Default behavior is to clear stored identity and reload the page.
-     * By either setting the disableDefaultIdleCallback flag or passing in a custom idle callback, we will ignore this config
-     */
-    if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
-      this.idleManager?.registerCallback(() => {
-        this.logout();
-        location.reload();
-      });
-    }
-  }
-
-  private async _handleSuccess(
-    key: SignIdentity | PartialIdentity,
-    delegationChain: DelegationChain,
-    onSuccess?: OnSuccessFunc,
-  ) {
-    if (!key) {
-      return;
-    }
-
-    this._key = key;
-    this._chain = delegationChain;
-
-    if ('toDer' in key) {
-      this._identity = PartialDelegationIdentity.fromDelegation(key, this._chain);
-    } else {
-      this._identity = DelegationIdentity.fromDelegation(key, this._chain);
-    }
-
-    const idleOptions = this._createOptions?.idleOptions;
-    // create the idle manager on a successful login if we haven't disabled it
-    // and it doesn't already exist.
-    if (!this.idleManager && !idleOptions?.disableIdle) {
-      this.idleManager = IdleManager.create(idleOptions);
-      this._registerDefaultIdleCallback();
-    }
-
-    if (this._chain) {
-      await this._storage.set(KEY_STORAGE_DELEGATION, JSON.stringify(this._chain.toJSON()));
-    }
-
-    // Persist the fresh key that was used for this login.
-    await persistKey(this._storage, this._key);
-
-    // onSuccess should be the last thing to do to avoid consumers
-    // interfering by navigating or refreshing the page
-    await onSuccess?.();
-  }
-
-  public getIdentity(): Identity {
-    return this._identity;
-  }
-
-  public async isAuthenticated(): Promise<boolean> {
-    return (
-      !this.getIdentity().getPrincipal().isAnonymous() &&
-      this._chain !== null &&
-      isDelegationValid(this._chain)
-    );
-  }
-
-  /**
-   * AuthClient Login - Opens up a new window to authenticate with Internet Identity
-   *
-   * Generates a fresh session key for every login attempt. If `onError` is provided,
-   * errors are routed to that callback; otherwise login() throws on failure.
-   *
-   * @param {AuthClientLoginOptions} options - Per-login options (maxTimeToLive, targets, callbacks).
-   * @param options.maxTimeToLive Expiration of the authentication in nanoseconds
-   * @param options.onSuccess Callback once login has completed
-   * @param options.onError Callback in case authentication fails
-   * @example
-   * const authClient = await AuthClient.create({
-   *  identityProvider: 'http://<canisterID>.127.0.0.1:8000',
-   *  windowOpenerFeatures: "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100",
-   * });
-   * authClient.login({
-   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000), // 1 week
-   *  onSuccess: () => {
-   *    console.log('Login Successful!');
-   *  },
-   *  onError: (error) => {
-   *    console.error('Login Failed: ', error);
-   *  }
-   * });
-   */
-  public async login(options?: AuthClientLoginOptions): Promise<void> {
-    // Set default maxTimeToLive to 8 hours
-    const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
-
-    try {
-      // Generate a fresh session key for every login attempt instead of reusing the stored one.
-      const key = this._createOptions?.identity
-        ?? await generateKey(this._createOptions?.keyType ?? ECDSA_KEY_LABEL);
-
-      const delegationChain = await this._signer.requestDelegation({
-        publicKey: key.getPublicKey(),
-        targets: options?.targets,
-        maxTimeToLive,
-      });
-
-      await this._handleSuccess(key, delegationChain, options?.onSuccess);
-    } catch (err) {
-      // If an onError callback is provided, route the error there (callback-style).
-      // Otherwise, re-throw so callers can use try/catch or .catch().
-      if (options?.onError) {
-        await options.onError((err as Error).message);
-      } else {
-        throw err;
-      }
-    } finally {
-      await this._signer.closeChannel();
-    }
-  }
-
-  public async logout(options: { returnTo?: string } = {}): Promise<void> {
-    await _deleteStorage(this._storage);
-
-    // Reset this auth client to a non-authenticated state.
-    this._identity = new AnonymousIdentity();
-    this._chain = null;
-
-    if (options.returnTo) {
-      try {
-        window.history.pushState({}, '', options.returnTo);
-      } catch {
-        window.location.href = options.returnTo;
-      }
-    }
-  }
-}
-
-async function _deleteStorage(storage: AuthClientStorage) {
-  await storage.remove(KEY_STORAGE_KEY);
-  await storage.remove(KEY_STORAGE_DELEGATION);
-  await storage.remove(KEY_VECTOR);
-}
-
-function toStoredKey(key: SignIdentity | PartialIdentity): StoredKey {
+function serializeKey(key: SignIdentity | PartialIdentity): StoredKey {
   if (key instanceof ECDSAKeyIdentity) {
     return key.getKeyPair();
   }
@@ -455,6 +155,371 @@ async function persistKey(
   storage: AuthClientStorage,
   key: SignIdentity | PartialIdentity,
 ): Promise<void> {
-  const serialized = toStoredKey(key);
+  const serialized = serializeKey(key);
   await storage.set(KEY_STORAGE_KEY, serialized);
+}
+
+async function restoreKey(
+  storage: AuthClientStorage,
+  keyType: BaseKeyType,
+): Promise<SignIdentity | PartialIdentity | null> {
+  const maybeIdentityStorage = await storage.get(KEY_STORAGE_KEY);
+  if (!maybeIdentityStorage) return null;
+
+  try {
+    if (typeof maybeIdentityStorage === 'object') {
+      if (keyType === ED25519_KEY_LABEL && typeof maybeIdentityStorage === 'string') {
+        return Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
+      }
+      return await ECDSAKeyIdentity.fromKeyPair(maybeIdentityStorage);
+    }
+    if (typeof maybeIdentityStorage === 'string') {
+      // Legacy identity – serialized Ed25519KeyIdentity.
+      return Ed25519KeyIdentity.fromJSON(maybeIdentityStorage);
+    }
+  } catch {
+    // Stored value isn't a valid identity serialization – ignore.
+  }
+  return null;
+}
+
+async function restoreChain(
+  storage: AuthClientStorage,
+): Promise<DelegationChain | null> {
+  const chainStorage = await storage.get(KEY_STORAGE_DELEGATION);
+  if (chainStorage === null || chainStorage === undefined) return null;
+
+  if (typeof chainStorage === 'object' && chainStorage !== null) {
+    throw new Error(
+      'Delegation chain is incorrectly stored. A delegation chain should be stored as a string.',
+    );
+  }
+
+  return DelegationChain.fromJSON(chainStorage as string);
+}
+
+function getExpirationFlag(): bigint | null {
+  try {
+    const raw = localStorage.getItem(KEY_STORAGE_EXPIRATION);
+    if (!raw) return null;
+    return BigInt(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function persistChain(
+  storage: AuthClientStorage,
+  chain: DelegationChain,
+): Promise<void> {
+  await storage.set(KEY_STORAGE_DELEGATION, JSON.stringify(chain.toJSON()));
+
+  // Write the earliest delegation expiration into localStorage for sync reads.
+  const expirations = chain.delegations
+    .map((d) => d.delegation.expiration)
+    .filter((e): e is bigint => e !== undefined);
+
+  if (expirations.length > 0) {
+    const earliest = expirations.reduce((a, b) => (a < b ? a : b));
+    try {
+      localStorage.setItem(KEY_STORAGE_EXPIRATION, earliest.toString());
+    } catch {
+      // localStorage may be unavailable – ignore.
+    }
+  }
+}
+
+async function deleteStorage(storage: AuthClientStorage): Promise<void> {
+  await storage.remove(KEY_STORAGE_KEY);
+  await storage.remove(KEY_STORAGE_DELEGATION);
+  await storage.remove(KEY_VECTOR);
+  try {
+    localStorage.removeItem(KEY_STORAGE_EXPIRATION);
+  } catch {
+    // localStorage may be unavailable – ignore.
+  }
+}
+
+async function migrateFromLocalStorage(
+  storage: AuthClientStorage,
+  keyType: BaseKeyType,
+): Promise<void> {
+  try {
+    const fallbackLocalStorage = new LocalStorage();
+    const localChain = await fallbackLocalStorage.get(KEY_STORAGE_DELEGATION);
+    const localKey = await fallbackLocalStorage.get(KEY_STORAGE_KEY);
+    // not relevant for Ed25519
+    if (localChain && localKey && keyType === ECDSA_KEY_LABEL) {
+      console.log('Discovered an identity stored in localstorage. Migrating to IndexedDB');
+      await storage.set(KEY_STORAGE_DELEGATION, localChain);
+      await storage.set(KEY_STORAGE_KEY, localKey);
+
+      // clean up
+      await fallbackLocalStorage.remove(KEY_STORAGE_DELEGATION);
+      await fallbackLocalStorage.remove(KEY_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.error(`error while attempting to recover localstorage: ${error}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AuthClient
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool to manage authentication and identity
+ * @see {@link AuthClient}
+ */
+export class AuthClient {
+  #identity: Identity | PartialIdentity = new AnonymousIdentity();
+  #key: SignIdentity | PartialIdentity | null = null;
+  #chain: DelegationChain | null = null;
+  #storage: AuthClientStorage;
+  #createOptions: AuthClientCreateOptions | undefined;
+  #signer: Signer;
+  #initPromise: Promise<void>;
+
+  idleManager: IdleManager | undefined;
+
+  /**
+   * Create an AuthClient to manage authentication and identity
+   * @param {AuthClientCreateOptions} options - Options for creating an {@link AuthClient}
+   * @see {@link AuthClientCreateOptions}
+   * @param options.identity Optional Identity to use as the base
+   * @see {@link SignIdentity}
+   * @param options.storage Storage mechanism for delegation credentials
+   * @see {@link AuthClientStorage}
+   * @param options.keyType Type of key to use for the base key
+   * @param {IdleOptions} options.idleOptions Configures an {@link IdleManager}
+   * @see {@link IdleOptions}
+   * Default behavior is to clear stored identity and reload the page when a user goes idle, unless you set the disableDefaultIdleCallback flag or pass in a custom idle callback.
+   * @example
+   * const authClient = new AuthClient({
+   *   idleOptions: {
+   *     disableIdle: true
+   *   }
+   * })
+   */
+  constructor(options: AuthClientCreateOptions = {}) {
+    this.#storage = options.storage ?? new IdbStorage();
+    this.#createOptions = options;
+
+    // Create transport and signer from create-time options so they are reusable across logins.
+    const identityProviderUrl =
+      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
+
+    const transport = new PostMessageTransport({
+      url: identityProviderUrl,
+      windowOpenerFeatures: options.windowOpenerFeatures,
+    });
+
+    this.#signer = new Signer({
+      transport,
+      derivationOrigin: options.derivationOrigin?.toString(),
+    });
+
+    // Fire-and-forget hydration; memoize the promise.
+    this.#initPromise = this.#hydrate();
+  }
+
+  #init(): Promise<void> {
+    return this.#initPromise;
+  }
+
+  async #hydrate(): Promise<void> {
+    const options = this.#createOptions ?? {};
+    const storage = this.#storage;
+    const keyType = options.keyType ?? ECDSA_KEY_LABEL;
+
+    let key: SignIdentity | PartialIdentity | null = null;
+
+    if (options.identity) {
+      key = options.identity;
+    } else {
+      key = await restoreKey(storage, keyType);
+
+      if (!key) {
+        // Attempt to migrate from localstorage
+        await migrateFromLocalStorage(storage, keyType);
+        key = await restoreKey(storage, keyType);
+      }
+    }
+
+    let chain: DelegationChain | null = null;
+
+    if (key) {
+      try {
+        if (options.identity) {
+          this.#identity = options.identity;
+        } else {
+          chain = await restoreChain(storage);
+          if (chain) {
+            if (!isDelegationValid(chain)) {
+              await deleteStorage(storage);
+              key = null;
+            } else {
+              if ('toDer' in key) {
+                this.#identity = PartialDelegationIdentity.fromDelegation(key, chain);
+              } else {
+                this.#identity = DelegationIdentity.fromDelegation(key, chain);
+              }
+            }
+          }
+        }
+      } catch (e) {
+        console.error(e);
+        await deleteStorage(storage);
+        key = null;
+      }
+    }
+
+    // Idle manager setup
+    if (options.idleOptions?.disableIdle) {
+      this.idleManager = undefined;
+    } else if (chain || options.identity) {
+      this.idleManager = IdleManager.create(options.idleOptions);
+    }
+
+    if (!key) {
+      if (keyType === ED25519_KEY_LABEL) {
+        key = Ed25519KeyIdentity.generate();
+      } else {
+        if (options.storage && keyType === ECDSA_KEY_LABEL) {
+          console.warn(
+            `You are using a custom storage provider that may not support CryptoKey storage. If you are using a custom storage provider that does not support CryptoKey storage, you should use '${ED25519_KEY_LABEL}' as the key type, as it can serialize to a string`,
+          );
+        }
+        key = await ECDSAKeyIdentity.generate();
+      }
+      await persistKey(storage, key);
+    }
+
+    this.#key = key;
+    this.#chain = chain;
+
+    this.#registerDefaultIdleCallback();
+  }
+
+  #registerDefaultIdleCallback() {
+    const idleOptions = this.#createOptions?.idleOptions;
+    /**
+     * Default behavior is to clear stored identity and reload the page.
+     * By either setting the disableDefaultIdleCallback flag or passing in a custom idle callback, we will ignore this config
+     */
+    if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
+      this.idleManager?.registerCallback(() => {
+        this.logout();
+        location.reload();
+      });
+    }
+  }
+
+  async getIdentity(): Promise<Identity> {
+    await this.#init();
+    return this.#identity;
+  }
+
+  isAuthenticated(): boolean {
+    const expiration = getExpirationFlag();
+    if (expiration === null) return false;
+    const nowNanos = BigInt(Date.now()) * BigInt(1_000_000);
+    return expiration > nowNanos;
+  }
+
+  /**
+   * AuthClient Login - Opens up a new window to authenticate with Internet Identity
+   *
+   * Generates a fresh session key for every login attempt. If `onError` is provided,
+   * errors are routed to that callback; otherwise login() throws on failure.
+   *
+   * @param {AuthClientLoginOptions} options - Per-login options (maxTimeToLive, targets, callbacks).
+   * @param options.maxTimeToLive Expiration of the authentication in nanoseconds
+   * @param options.onSuccess Callback once login has completed
+   * @param options.onError Callback in case authentication fails
+   * @example
+   * const authClient = new AuthClient({
+   *  identityProvider: 'http://<canisterID>.127.0.0.1:8000',
+   *  windowOpenerFeatures: "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100",
+   * });
+   * authClient.login({
+   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000), // 1 week
+   *  onSuccess: () => {
+   *    console.log('Login Successful!');
+   *  },
+   *  onError: (error) => {
+   *    console.error('Login Failed: ', error);
+   *  }
+   * });
+   */
+  async login(options?: AuthClientLoginOptions): Promise<void> {
+    // Set default maxTimeToLive to 8 hours
+    const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
+
+    try {
+      // Generate a fresh session key for every login attempt instead of reusing the stored one.
+      const key =
+        this.#createOptions?.identity ??
+        (await generateKey(this.#createOptions?.keyType ?? ECDSA_KEY_LABEL));
+
+      const delegationChain = await this.#signer.requestDelegation({
+        publicKey: key.getPublicKey(),
+        targets: options?.targets,
+        maxTimeToLive,
+      });
+
+      // --- inline _handleSuccess logic ---
+      this.#key = key;
+      this.#chain = delegationChain;
+
+      if ('toDer' in key) {
+        this.#identity = PartialDelegationIdentity.fromDelegation(key, this.#chain);
+      } else {
+        this.#identity = DelegationIdentity.fromDelegation(key, this.#chain);
+      }
+
+      const idleOptions = this.#createOptions?.idleOptions;
+      if (!this.idleManager && !idleOptions?.disableIdle) {
+        this.idleManager = IdleManager.create(idleOptions);
+        this.#registerDefaultIdleCallback();
+      }
+
+      if (this.#chain) {
+        await persistChain(this.#storage, this.#chain);
+      }
+
+      // Persist the fresh key that was used for this login.
+      await persistKey(this.#storage, this.#key);
+
+      // onSuccess should be the last thing to do to avoid consumers
+      // interfering by navigating or refreshing the page
+      await options?.onSuccess?.();
+    } catch (err) {
+      // If an onError callback is provided, route the error there (callback-style).
+      // Otherwise, re-throw so callers can use try/catch or .catch().
+      if (options?.onError) {
+        await options.onError((err as Error).message);
+      } else {
+        throw err;
+      }
+    } finally {
+      await this.#signer.closeChannel();
+    }
+  }
+
+  async logout(options: { returnTo?: string } = {}): Promise<void> {
+    await deleteStorage(this.#storage);
+
+    // Reset this auth client to a non-authenticated state.
+    this.#identity = new AnonymousIdentity();
+    this.#chain = null;
+
+    if (options.returnTo) {
+      try {
+        window.history.pushState({}, '', options.returnTo);
+      } catch {
+        window.location.href = options.returnTo;
+      }
+    }
+  }
 }

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -41,9 +41,11 @@ beforeEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   vi.clearAllMocks();
+  localStorage.clear();
 });
 
 afterEach(() => {
+  localStorage.clear();
   // Tear down the IdleManager singleton between tests to avoid leaking state.
   try {
     IdleManager.create().exit();
@@ -54,34 +56,38 @@ afterEach(() => {
 
 describe('Auth Client', () => {
   it('should initialize with an AnonymousIdentity', async () => {
-    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
-    expect(await test.isAuthenticated()).toBe(false);
-    expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(true);
+    const test = new AuthClient({ idleOptions: { disableIdle: true } });
+    expect(test.isAuthenticated()).toBe(false);
+    expect((await test.getIdentity()).getPrincipal().isAnonymous()).toBe(true);
   });
 
   it('should initialize with a provided identity', async () => {
     const identity = Ed25519KeyIdentity.generate();
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       identity,
     });
-    expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(false);
-    expect(test.getIdentity()).toBe(identity);
+    expect((await test.getIdentity()).getPrincipal().isAnonymous()).toBe(false);
+    expect(await test.getIdentity()).toBe(identity);
   });
 
   it('should log users out', async () => {
-    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const test = new AuthClient({ idleOptions: { disableIdle: true } });
     await test.logout();
-    expect(await test.isAuthenticated()).toBe(false);
-    expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(true);
+    expect(test.isAuthenticated()).toBe(false);
+    expect((await test.getIdentity()).getPrincipal().isAnonymous()).toBe(true);
   });
 
   it('should not initialize an idleManager if the user is not logged in', async () => {
-    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const test = new AuthClient({ idleOptions: { disableIdle: true } });
+    // Wait for hydration to complete
+    await test.getIdentity();
     expect(test.idleManager).not.toBeDefined();
   });
 
   it('should initialize an idleManager if an identity is passed', async () => {
-    const test = await AuthClient.create({ identity: Ed25519KeyIdentity.generate() });
+    const test = new AuthClient({ identity: Ed25519KeyIdentity.generate() });
+    // Wait for hydration to complete
+    await test.getIdentity();
     expect(test.idleManager).toBeDefined();
   });
 
@@ -106,12 +112,15 @@ describe('Auth Client', () => {
     };
 
     // setup auth client
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       identity,
       idleOptions: {
         idleTimeout: 1000,
       },
     });
+
+    // Wait for hydration
+    await test.getIdentity();
 
     const httpAgent = await HttpAgent.create({ fetch: mockFetch });
     const actor = Actor.createActor(actorInterface, { canisterId, agent: httpAgent });
@@ -132,19 +141,22 @@ describe('Auth Client', () => {
     try {
       await actor.greet('hello');
     } catch (error) {
-      expect(await test.isAuthenticated()).toBe(false);
+      expect(test.isAuthenticated()).toBe(false);
       expect((error as AgentError).message).toBe(expectedError);
     }
   });
 
   it('should not set up an idle timer if the disable option is set', async () => {
     const idleFn = vi.fn();
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       idleOptions: {
         idleTimeout: 1000,
         disableIdle: true,
       },
     });
+
+    // Wait for hydration
+    await test.getIdentity();
 
     expect(idleFn).not.toHaveBeenCalled();
     expect(test.idleManager).toBeUndefined();
@@ -170,7 +182,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     const onSuccess = vi.fn();
     await client.login({ onSuccess });
 
@@ -184,7 +196,7 @@ describe('Auth Client login', () => {
       new Error('mock error message'),
     );
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     const onError = vi.fn();
     await client.login({ onError });
 
@@ -197,7 +209,7 @@ describe('Auth Client login', () => {
       new Error('mock throw message'),
     );
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     await expect(client.login()).rejects.toThrow('mock throw message');
     expect(mockSignerInstance.closeChannel).toHaveBeenCalledOnce();
   });
@@ -207,7 +219,7 @@ describe('Auth Client login', () => {
       new Error('callback error'),
     );
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     const onError = vi.fn();
 
     // Should NOT throw
@@ -219,7 +231,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     const onError = vi.fn();
     const onSuccess = vi.fn(() => {
       throw new Error('onSuccess error');
@@ -234,7 +246,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({
+    const client = new AuthClient({
       identityProvider: 'http://127.0.0.1',
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
       idleOptions: { disableIdle: true },
@@ -251,7 +263,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     await client.login();
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
@@ -265,7 +277,7 @@ describe('Auth Client login', () => {
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
     // derivationOrigin is now set at create-time and passed via Signer constructor.
-    const client = await AuthClient.create({
+    const client = new AuthClient({
       identityProvider: 'http://127.0.0.1',
       derivationOrigin: 'http://127.0.0.1:1234',
       idleOptions: { disableIdle: true },
@@ -280,7 +292,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     await client.login({ maxTimeToLive: BigInt(1000) });
 
     const callArgs = mockSignerInstance.requestDelegation.mock.calls[0][0];
@@ -291,10 +303,10 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
     await client.login();
 
-    expect(client.getIdentity().getPrincipal().isAnonymous()).toBe(false);
+    expect((await client.getIdentity()).getPrincipal().isAnonymous()).toBe(false);
   });
 
   it('should persist delegation and key to storage after login', async () => {
@@ -307,7 +319,7 @@ describe('Auth Client login', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
     await client.login();
 
     // Should have set the delegation chain
@@ -341,7 +353,7 @@ describe('Auth Client login', () => {
       }),
     };
 
-    const client = await AuthClient.create({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
 
     await client.login();
     const keyAfterFirstLogin = fakeStore[KEY_STORAGE_KEY];
@@ -353,11 +365,11 @@ describe('Auth Client login', () => {
     expect(keyAfterFirstLogin).not.toEqual(keyAfterSecondLogin);
   });
 
-  it('should use the identityProvider passed to the create method', async () => {
+  it('should use the identityProvider passed to the constructor', async () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create({
+    const client = new AuthClient({
       identityProvider: 'http://my-local-website.localhost:8080',
       idleOptions: { disableIdle: true },
     });
@@ -386,7 +398,7 @@ describe('Auth Client login', () => {
       set: vi.fn(),
     };
 
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       storage,
       idleOptions: {
         idleTimeout: 1000,
@@ -420,7 +432,7 @@ describe('Auth Client login', () => {
       set: vi.fn(),
     };
 
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       storage,
       idleOptions: {
         idleTimeout: 1000,
@@ -457,7 +469,7 @@ describe('Auth Client login', () => {
     };
 
     const idleCb = vi.fn();
-    const test = await AuthClient.create({
+    const test = new AuthClient({
       storage,
       idleOptions: {
         idleTimeout: 1000,
@@ -484,12 +496,15 @@ describe('Auth Client login', () => {
       set: vi.fn(),
     };
 
-    await AuthClient.create({
+    const client = new AuthClient({
       storage,
       idleOptions: {
         idleTimeout: 1000,
       },
     });
+
+    // Wait for hydration
+    await client.getIdentity();
 
     expect(storage.set).toHaveBeenCalled();
     expect(storage.remove).not.toHaveBeenCalled();
@@ -501,6 +516,73 @@ describe('Auth Client login', () => {
     expect(storage.remove).not.toHaveBeenCalled();
     // Page should not be reloaded
     expect(window.location.reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('localStorage expiration flag', () => {
+  function setupMockDelegation() {
+    const key = Ed25519KeyIdentity.generate();
+    const chain = DelegationChain.create(
+      key,
+      key.getPublicKey(),
+      new Date(Date.now() + 60 * 60 * 1000),
+    );
+    return chain;
+  }
+
+  it('should set the expiration flag in localStorage on login', async () => {
+    const chain = await setupMockDelegation();
+    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
+
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    expect(localStorage.getItem('ic-delegation_expiration')).toBeNull();
+
+    await client.login();
+
+    const stored = localStorage.getItem('ic-delegation_expiration');
+    expect(stored).not.toBeNull();
+    // The expiration should be a bigint string representing nanoseconds in the future
+    const expNanos = BigInt(stored!);
+    const nowNanos = BigInt(Date.now()) * BigInt(1_000_000);
+    expect(expNanos).toBeGreaterThan(nowNanos);
+  });
+
+  it('should clear the expiration flag on logout', async () => {
+    const chain = await setupMockDelegation();
+    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
+
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    await client.login();
+
+    expect(localStorage.getItem('ic-delegation_expiration')).not.toBeNull();
+
+    await client.logout();
+
+    expect(localStorage.getItem('ic-delegation_expiration')).toBeNull();
+  });
+
+  it('isAuthenticated should return true when expiration is in the future', async () => {
+    const chain = await setupMockDelegation();
+    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
+
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    await client.login();
+
+    expect(client.isAuthenticated()).toBe(true);
+  });
+
+  it('isAuthenticated should return false when expiration is in the past', async () => {
+    // Manually set a past expiration
+    const pastNanos = (BigInt(Date.now()) - BigInt(60_000)) * BigInt(1_000_000);
+    localStorage.setItem('ic-delegation_expiration', pastNanos.toString());
+
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    expect(client.isAuthenticated()).toBe(false);
+  });
+
+  it('isAuthenticated should return false when no expiration is set', () => {
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    expect(client.isAuthenticated()).toBe(false);
   });
 });
 
@@ -521,7 +603,9 @@ describe('Migration from localstorage', () => {
       set: vi.fn(),
     };
 
-    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    // Wait for hydration to complete
+    await client.getIdentity();
 
     // Key is stored during creation when none is provided
     expect(storage.set).toHaveBeenCalledTimes(1);
@@ -538,23 +622,27 @@ describe('Migration from localstorage', () => {
       set: vi.fn(),
     };
 
-    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    // Wait for hydration to complete
+    await client.getIdentity();
 
     expect(storage.set).toHaveBeenCalledTimes(1);
   });
 
   it('should migrate storage from localstorage', async () => {
-    const localStorage = new LocalStorage();
+    const ls = new LocalStorage();
     const storage: AuthClientStorage = {
       remove: vi.fn(),
       get: vi.fn(),
       set: vi.fn(),
     };
 
-    await localStorage.set(KEY_STORAGE_DELEGATION, 'test');
-    await localStorage.set(KEY_STORAGE_KEY, 'key');
+    await ls.set(KEY_STORAGE_DELEGATION, 'test');
+    await ls.set(KEY_STORAGE_KEY, 'key');
 
-    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    // Wait for hydration to complete
+    await client.getIdentity();
 
     expect(storage.set).toHaveBeenCalledTimes(3);
   });
@@ -585,9 +673,9 @@ describe('Migration from Ed25519Key', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage });
+    const client = new AuthClient({ storage });
 
-    const identity = client.getIdentity();
+    const identity = await client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(false);
   });
 
@@ -604,9 +692,9 @@ describe('Migration from Ed25519Key', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
 
-    const identity = client.getIdentity();
+    const identity = await client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
   });
 
@@ -634,9 +722,9 @@ describe('Migration from Ed25519Key', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
 
-    const identity = client.getIdentity();
+    const identity = await client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
 
     // expect the delegation to be removed
@@ -653,7 +741,9 @@ describe('Migration from Ed25519Key', () => {
         fakeStore[x] = y;
       }),
     };
-    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    // Wait for hydration
+    await client.getIdentity();
 
     // It should have stored a cryptoKey
     expect(Object.keys(fakeStore[KEY_STORAGE_KEY])).toMatchInlineSnapshot(`
@@ -681,13 +771,13 @@ describe('Migration from Ed25519Key', () => {
       return key;
     });
 
-    const client1 = await AuthClient.create({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
-    const identity1 = client1.getIdentity();
+    const client1 = new AuthClient({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
+    const identity1 = await client1.getIdentity();
 
     // This auth client should find the Ed25519 key in the storage,
     // and not generate a new one
-    const client2 = await AuthClient.create({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
-    const identity2 = client2.getIdentity();
+    const client2 = new AuthClient({ storage, keyType: 'Ed25519', idleOptions: { disableIdle: true } });
+    const identity2 = await client2.getIdentity();
 
     expect(generate).toHaveBeenCalledTimes(1);
     // The first identity, created from testSecrets, should be the same as the second identity,


### PR DESCRIPTION
Changes the `AuthClient` API for better ergonomics:

- **Sync constructor**: `new AuthClient()` replaces `await AuthClient.create()`. Session hydration from IndexedDB happens eagerly in the background and is awaited transparently by `getIdentity()`. This avoids popups being blocked when `AuthClient` is constructed in the same click handler as `login()`.
- **Sync `isAuthenticated()`**: Reads a cached delegation expiration from `localStorage` — no `await` needed.
- **Async `getIdentity()`**: Returns the hydrated identity, awaiting the background restore if still in progress.
- **ES private fields**: Replaced TS `private`/`public` keywords with `#` fields.
- **Code organization**: Persistence helpers extracted as free functions outside the class.

BREAKING CHANGE:
- `AuthClient.create()` removed — use `new AuthClient()` instead
- `getIdentity()` is now async (returns `Promise<Identity>`)
- `isAuthenticated()` is now sync (returns `boolean` instead of `Promise<boolean>`)