### PR TITLE
feat: one-click OpenID sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ try {
 await authClient.logout();
 ```
 
+### One-Click OpenID Sign-In
+
+Skip the Internet Identity authentication method screen and offer sign-in options like Google directly in your app:
+
+```typescript
+const authClient = new AuthClient({
+  openIdProvider: 'google', // or 'apple' or 'microsoft'
+});
+
+await authClient.login();
+```
+
 Additional documentation can be found [here](https://js.icp.build/auth/latest/).
 
 ## Contributing

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -40,6 +40,14 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
+export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
+
+const OPENID_PROVIDER_URLS: Record<OpenIdProvider, string> = {
+  google: 'https://accounts.google.com',
+  apple: 'https://appleid.apple.com',
+  microsoft: 'https://login.microsoftonline.com/{tid}/v2.0',
+};
+
 /**
  * List of options for creating an {@link AuthClient}.
  */
@@ -86,6 +94,13 @@ export interface AuthClientCreateOptions {
    * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
    */
   windowOpenerFeatures?: string;
+
+  /**
+   * OpenID provider for one-click sign-in. When set, the identity provider
+   * URL includes an `openid` search param so the user authenticates via
+   * the chosen provider (e.g. Google) instead of seeing Internet Identity directly.
+   */
+  openIdProvider?: OpenIdProvider;
 }
 
 export interface IdleOptions extends IdleManagerOptions {
@@ -306,11 +321,15 @@ export class AuthClient {
     this.#createOptions = options;
 
     // Create transport and signer from create-time options so they are reusable across logins.
-    const identityProviderUrl =
-      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
+    const identityProviderUrl = new URL(
+      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
+    );
+    if (options.openIdProvider) {
+      identityProviderUrl.searchParams.set('openid', OPENID_PROVIDER_URLS[options.openIdProvider]);
+    }
 
     const transport = new PostMessageTransport({
-      url: identityProviderUrl,
+      url: identityProviderUrl.toString(),
       windowOpenerFeatures: options.windowOpenerFeatures,
     });
 

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -167,6 +167,26 @@ describe('Auth Client', () => {
   });
 });
 
+describe('OpenID provider', () => {
+  it.each([
+    ['google', 'https://accounts.google.com'],
+    ['apple', 'https://appleid.apple.com'],
+    ['microsoft', 'https://login.microsoftonline.com/{tid}/v2.0'],
+  ] as const)('should pass openid=%s search param to the transport', (provider, expectedUrl) => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({ openIdProvider: provider, idleOptions: { disableIdle: true } });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.get('openid')).toBe(expectedUrl);
+  });
+
+  it('should not include openid search param when openIdProvider is not set', () => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({ idleOptions: { disableIdle: true } });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.has('openid')).toBe(false);
+  });
+});
+
 describe('Auth Client login', () => {
   function setupMockDelegation() {
     const key = Ed25519KeyIdentity.generate();
@@ -254,7 +274,7 @@ describe('Auth Client login', () => {
     await client.login();
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
-      url: 'http://127.0.0.1',
+      url: 'http://127.0.0.1/',
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
     });
   });
@@ -377,7 +397,7 @@ describe('Auth Client login', () => {
     await client.login({ maxTimeToLive: BigInt(1000) });
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
-      url: 'http://my-local-website.localhost:8080',
+      url: 'http://my-local-website.localhost:8080/',
       windowOpenerFeatures: undefined,
     });
 


### PR DESCRIPTION
Adds support for one-click sign-in via OpenID providers. When `openIdProvider` is set on `AuthClientCreateOptions`, the identity provider URL includes an `openid` search param, allowing the user to skip the Internet Identity authentication method screen and authenticate via Google, Apple, or Microsoft directly.

Supported providers:
- `'google'` → `https://accounts.google.com`
- `'apple'` → `https://appleid.apple.com`
- `'microsoft'` → `https://login.microsoftonline.com/{tid}/v2.0`

```typescript
const authClient = new AuthClient({
  openIdProvider: 'google',
});
await authClient.login();
```