### PR TITLE
feat: fresh session keys, improved error handling, singleton IdleManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
     "@icp-sdk/core": "^5.2.1",
+    "@icp-sdk/signer": "^5.2.0",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^27.4.0",
     "publint": "^0.3.18",
@@ -62,7 +63,6 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.2.0",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@icp-sdk/signer':
-        specifier: ^5.2.0
-        version: 5.2.0(@icp-sdk/core@5.2.1)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -21,6 +18,9 @@ importers:
       '@icp-sdk/core':
         specifier: ^5.2.1
         version: 5.2.1
+      '@icp-sdk/signer':
+        specifier: ^5.2.0
+        version: 5.2.0(@icp-sdk/core@5.2.1)
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -64,9 +64,22 @@ export interface AuthClientCreateOptions {
   idleOptions?: IdleOptions;
 
   /**
-   * Options to handle login, passed to the login method
+   * Identity provider
+   * @default "https://id.ai/authorize"
    */
-  loginOptions?: AuthClientLoginOptions;
+  identityProvider?: string | URL;
+
+  /**
+   * Origin for Identity Provider to use while generating the delegated identity. For II, the derivation origin must authorize this origin by setting a record at `<derivation-origin>/.well-known/ii-alternative-origins`.
+   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   */
+  derivationOrigin?: string | URL;
+
+  /**
+   * Auth Window feature config string
+   * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
+   */
+  windowOpenerFeatures?: string;
 }
 
 export interface IdleOptions extends IdleManagerOptions {
@@ -89,37 +102,33 @@ export type OnErrorFunc = (error?: string) => void | Promise<void>;
 
 export interface AuthClientLoginOptions {
   /**
-   * Identity provider
-   * @default "https://id.ai/authorize"
-   */
-  identityProvider?: string | URL;
-  /**
    * Expiration of the authentication in nanoseconds
    * @default  BigInt(8) hours * BigInt(3_600_000_000_000) nanoseconds
    */
   maxTimeToLive?: bigint;
   /**
-   * Origin for Identity Provider to use while generating the delegated identity. For II, the derivation origin must authorize this origin by setting a record at `<derivation-origin>/.well-known/ii-alternative-origins`.
-   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   * Optional canister targets for the delegation.
    */
-  derivationOrigin?: string | URL;
-  /**
-   * Auth Window feature config string
-   * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
-   */
-  windowOpenerFeatures?: string;
+  targets?: Principal[];
   /**
    * Callback once login has completed
    */
   onSuccess?: OnSuccessFunc;
   /**
-   * Callback in case authentication fails
+   * Callback in case authentication fails.
+   * When provided, errors are passed to this callback instead of being thrown.
    */
   onError?: OnErrorFunc;
-  /**
-   * Optional canister targets for the delegation.
-   */
-  targets?: Principal[];
+}
+
+/**
+ * Generates a fresh session key of the given type.
+ */
+async function generateKey(keyType: BaseKeyType): Promise<SignIdentity> {
+  if (keyType === ED25519_KEY_LABEL) {
+    return Ed25519KeyIdentity.generate();
+  }
+  return await ECDSAKeyIdentity.generate();
 }
 
 /**
@@ -256,7 +265,20 @@ export class AuthClient {
       await persistKey(storage, key);
     }
 
-    return new AuthClient(identity, key, chain, storage, idleManager, options);
+    // Create transport and signer from create-time options so they are reusable across logins.
+    const identityProviderUrl = options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
+
+    const transport = new PostMessageTransport({
+      url: identityProviderUrl,
+      windowOpenerFeatures: options.windowOpenerFeatures,
+    });
+
+    const signer = new Signer({
+      transport,
+      derivationOrigin: options.derivationOrigin?.toString(),
+    });
+
+    return new AuthClient(identity, key, chain, storage, idleManager, options, signer);
   }
 
   protected constructor(
@@ -266,6 +288,7 @@ export class AuthClient {
     private _storage: AuthClientStorage,
     public idleManager: IdleManager | undefined,
     private _createOptions: AuthClientCreateOptions | undefined,
+    private _signer: Signer,
   ) {
     this._registerDefaultIdleCallback();
   }
@@ -284,12 +307,16 @@ export class AuthClient {
     }
   }
 
-  private async _handleSuccess(delegationChain: DelegationChain, onSuccess?: OnSuccessFunc) {
-    const key = this._key;
+  private async _handleSuccess(
+    key: SignIdentity | PartialIdentity,
+    delegationChain: DelegationChain,
+    onSuccess?: OnSuccessFunc,
+  ) {
     if (!key) {
       return;
     }
 
+    this._key = key;
     this._chain = delegationChain;
 
     if ('toDer' in key) {
@@ -310,9 +337,7 @@ export class AuthClient {
       await this._storage.set(KEY_STORAGE_DELEGATION, JSON.stringify(this._chain.toJSON()));
     }
 
-    // Ensure the stored key in persistent storage matches the in-memory key that
-    // was used to obtain the delegation. This avoids key/delegation mismatches
-    // across multiple tabs overwriting each other's cached keys.
+    // Persist the fresh key that was used for this login.
     await persistKey(this._storage, this._key);
 
     // onSuccess should be the last thing to do to avoid consumers
@@ -334,19 +359,21 @@ export class AuthClient {
 
   /**
    * AuthClient Login - Opens up a new window to authenticate with Internet Identity
-   * @param {AuthClientLoginOptions} options - Options for logging in, merged with the options set during creation if any.
-   * @param options.identityProvider Identity provider
+   *
+   * Generates a fresh session key for every login attempt. If `onError` is provided,
+   * errors are routed to that callback; otherwise login() throws on failure.
+   *
+   * @param {AuthClientLoginOptions} options - Per-login options (maxTimeToLive, targets, callbacks).
    * @param options.maxTimeToLive Expiration of the authentication in nanoseconds
-   * @param options.derivationOrigin Origin for Identity Provider to use while generating the delegated identity
-   * @param options.windowOpenerFeatures Configures the opened authentication window
    * @param options.onSuccess Callback once login has completed
    * @param options.onError Callback in case authentication fails
    * @example
-   * const authClient = await AuthClient.create();
-   * authClient.login({
+   * const authClient = await AuthClient.create({
    *  identityProvider: 'http://<canisterID>.127.0.0.1:8000',
-   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000), // 1 week
    *  windowOpenerFeatures: "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100",
+   * });
+   * authClient.login({
+   *  maxTimeToLive: BigInt (7) * BigInt(24) * BigInt(3_600_000_000_000), // 1 week
    *  onSuccess: () => {
    *    console.log('Login Successful!');
    *  },
@@ -356,37 +383,34 @@ export class AuthClient {
    * });
    */
   public async login(options?: AuthClientLoginOptions): Promise<void> {
-    // Merge the passed options with the options set during creation
-    const loginOptions = mergeLoginOptions(this._createOptions?.loginOptions, options);
-
     // Set default maxTimeToLive to 8 hours
-    const maxTimeToLive = loginOptions?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
-
-    const identityProviderUrl =
-      loginOptions?.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
-
-    const transport = new PostMessageTransport({
-      url: identityProviderUrl,
-      windowOpenerFeatures: loginOptions?.windowOpenerFeatures,
-    });
-
-    const signer = new Signer({
-      transport,
-      derivationOrigin: loginOptions?.derivationOrigin?.toString(),
-    });
+    const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
 
     try {
-      const delegationChain = await signer.requestDelegation({
-        publicKey: this._key.getPublicKey(),
-        targets: loginOptions?.targets,
+      await this._signer.openChannel();
+
+      // Generate a fresh session key for every login attempt instead of reusing the stored one.
+      const key =
+        this._createOptions?.identity ??
+        (await generateKey(this._createOptions?.keyType ?? ECDSA_KEY_LABEL));
+
+      const delegationChain = await this._signer.requestDelegation({
+        publicKey: key.getPublicKey(),
+        targets: options?.targets,
         maxTimeToLive,
       });
 
-      await this._handleSuccess(delegationChain, loginOptions?.onSuccess);
+      await this._handleSuccess(key, delegationChain, options?.onSuccess);
     } catch (err) {
-      loginOptions?.onError?.((err as Error).message);
+      // If an onError callback is provided, route the error there (callback-style).
+      // Otherwise, re-throw so callers can use try/catch or .catch().
+      if (options?.onError) {
+        await options.onError((err as Error).message);
+      } else {
+        throw err;
+      }
     } finally {
-      await signer.closeChannel();
+      await this._signer.closeChannel();
     }
   }
 
@@ -411,20 +435,6 @@ async function _deleteStorage(storage: AuthClientStorage) {
   await storage.remove(KEY_STORAGE_KEY);
   await storage.remove(KEY_STORAGE_DELEGATION);
   await storage.remove(KEY_VECTOR);
-}
-
-function mergeLoginOptions(
-  loginOptions: AuthClientLoginOptions | undefined,
-  otherLoginOptions: AuthClientLoginOptions | undefined,
-): AuthClientLoginOptions | undefined {
-  if (!loginOptions && !otherLoginOptions) {
-    return undefined;
-  }
-
-  return {
-    ...loginOptions,
-    ...otherLoginOptions,
-  };
 }
 
 function toStoredKey(key: SignIdentity | PartialIdentity): StoredKey {

--- a/src/client/idle-manager.ts
+++ b/src/client/idle-manager.ts
@@ -7,7 +7,7 @@ export type IdleManagerOptions = {
   onIdle?: IdleCB;
   /**
    * timeout in ms
-   * @default 30 minutes [600_000]
+   * @default 10 minutes [600_000]
    */
   idleTimeout?: number;
   /**
@@ -27,15 +27,23 @@ const events = ['mousedown', 'mousemove', 'keydown', 'touchstart', 'wheel'];
 /**
  * Detects if the user has been idle for a duration of `idleTimeout` ms, and calls `onIdle` and registered callbacks.
  * By default, the IdleManager will log a user out after 10 minutes of inactivity.
- * To override these defaults, you can pass an `onIdle` callback, or configure a custom `idleTimeout` in milliseconds
+ * To override these defaults, you can pass an `onIdle` callback, or configure a custom `idleTimeout` in milliseconds.
+ *
+ * IdleManager is a singleton: multiple calls to `create()` return the same instance,
+ * registering any new `onIdle` callback. Call `exit()` to tear down the singleton.
  */
 export class IdleManager {
-  callbacks: IdleCB[] = [];
-  idleTimeout: IdleManagerOptions['idleTimeout'] = 10 * 60 * 1000;
-  timeoutID?: number = undefined;
+  static #instance: IdleManager | undefined;
+
+  #callbacks: IdleCB[] = [];
+  #idleTimeout: number;
+  #timeoutID?: number = undefined;
+  #resetTimer: () => void;
 
   /**
-   * Creates an {@link IdleManager}
+   * Creates or returns the singleton {@link IdleManager}.
+   * If the instance already exists, any provided `onIdle` callback is registered
+   * on the existing instance.
    * @param {IdleManagerOptions} options Optional configuration
    * @see {@link IdleManagerOptions}
    * @param options.onIdle Callback once user has been idle. Use to prompt for fresh login, and use `Actor.agentOf(your_actor).invalidateIdentity()` to protect the user
@@ -67,25 +75,34 @@ export class IdleManager {
       scrollDebounce?: number;
     } = {},
   ): IdleManager {
-    return new IdleManager(options);
+    if (IdleManager.#instance) {
+      if (options.onIdle) {
+        IdleManager.#instance.registerCallback(options.onIdle);
+      }
+      return IdleManager.#instance;
+    }
+    const instance = new IdleManager(options);
+    IdleManager.#instance = instance;
+    return instance;
   }
 
   /**
-   * @protected
    * @param options {@link IdleManagerOptions}
    */
-  protected constructor(options: IdleManagerOptions = {}) {
+  private constructor(options: IdleManagerOptions = {}) {
     const { onIdle, idleTimeout = 10 * 60 * 1000 } = options || {};
 
-    this.callbacks = onIdle ? [onIdle] : [];
-    this.idleTimeout = idleTimeout;
+    this.#callbacks = onIdle ? [onIdle] : [];
+    this.#idleTimeout = idleTimeout;
 
-    const _resetTimer = this._resetTimer.bind(this);
+    // Store the bound function once so the same reference is used
+    // for both addEventListener and removeEventListener.
+    this.#resetTimer = this._resetTimer.bind(this);
 
-    window.addEventListener('load', _resetTimer, true);
+    window.addEventListener('load', this.#resetTimer, true);
 
     events.forEach((name) => {
-      document.addEventListener(name, _resetTimer, true);
+      document.addEventListener(name, this.#resetTimer, true);
     });
 
     const debounce = (func: (...args: unknown[]) => void, wait: number) => {
@@ -103,42 +120,43 @@ export class IdleManager {
 
     if (options?.captureScroll) {
       // debounce scroll events
-      const scroll = debounce(_resetTimer, options?.scrollDebounce ?? 100);
+      const scroll = debounce(this.#resetTimer, options?.scrollDebounce ?? 100);
       window.addEventListener('scroll', scroll, true);
     }
 
-    _resetTimer();
+    this.#resetTimer();
   }
 
   /**
    * @param {IdleCB} callback function to be called when user goes idle
    */
   public registerCallback(callback: IdleCB): void {
-    this.callbacks.push(callback);
+    this.#callbacks.push(callback);
   }
 
   /**
-   * Cleans up the idle manager and its listeners
+   * Tears down listeners, fires all callbacks, and clears the singleton.
    */
   public exit(): void {
-    clearTimeout(this.timeoutID);
-    window.removeEventListener('load', this._resetTimer, true);
+    clearTimeout(this.#timeoutID);
+    window.removeEventListener('load', this.#resetTimer, true);
 
-    const _resetTimer = this._resetTimer.bind(this);
     events.forEach((name) => {
-      document.removeEventListener(name, _resetTimer, true);
+      document.removeEventListener(name, this.#resetTimer, true);
     });
-    this.callbacks.forEach((cb) => {
+    this.#callbacks.forEach((cb) => {
       cb();
     });
+
+    IdleManager.#instance = undefined;
   }
 
   /**
    * Resets the timeouts during cleanup
    */
-  _resetTimer(): void {
+  private _resetTimer(): void {
     const exit = this.exit.bind(this);
-    window.clearTimeout(this.timeoutID);
-    this.timeoutID = window.setTimeout(exit, this.idleTimeout);
+    window.clearTimeout(this.#timeoutID);
+    this.#timeoutID = window.setTimeout(exit, this.#idleTimeout);
   }
 }

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -41,7 +41,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Tear down the IdleManager singleton between tests to avoid leaking state.
+  // IdleManager is a singleton — without tearing it down, idle timers and DOM
+  // listeners from one test bleed into the next, causing spurious failures.
   try {
     IdleManager.create().exit();
   } catch {

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -1,16 +1,16 @@
 import { Actor, type AgentError, HttpAgent } from '@icp-sdk/core/agent';
 import { IDL } from '@icp-sdk/core/candid';
-import { DelegationChain, ECDSAKeyIdentity, Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import { DelegationChain, Ed25519KeyIdentity } from '@icp-sdk/core/identity';
 import { Principal } from '@icp-sdk/core/principal';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthClient } from '../../src/client/auth-client.ts';
+import { IdleManager } from '../../src/client/idle-manager.ts';
 import {
   type AuthClientStorage,
   IdbStorage,
   KEY_STORAGE_DELEGATION,
   KEY_STORAGE_KEY,
   LocalStorage,
-  type StoredKey,
 } from '../../src/client/storage.ts';
 
 const { mockSignerInstance, mockPostMessageTransport } = vi.hoisted(() => ({
@@ -40,9 +40,18 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+afterEach(() => {
+  // Tear down the IdleManager singleton between tests to avoid leaking state.
+  try {
+    IdleManager.create().exit();
+  } catch {
+    // ignore if already torn down
+  }
+});
+
 describe('Auth Client', () => {
   it('should initialize with an AnonymousIdentity', async () => {
-    const test = await AuthClient.create();
+    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
     expect(await test.isAuthenticated()).toBe(false);
     expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(true);
   });
@@ -57,14 +66,14 @@ describe('Auth Client', () => {
   });
 
   it('should log users out', async () => {
-    const test = await AuthClient.create();
+    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
     await test.logout();
     expect(await test.isAuthenticated()).toBe(false);
     expect(test.getIdentity().getPrincipal().isAnonymous()).toBe(true);
   });
 
   it('should not initialize an idleManager if the user is not logged in', async () => {
-    const test = await AuthClient.create();
+    const test = await AuthClient.create({ idleOptions: { disableIdle: true } });
     expect(test.idleManager).not.toBeDefined();
   });
 
@@ -158,7 +167,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     const onSuccess = vi.fn();
     await client.login({ onSuccess });
 
@@ -170,7 +179,7 @@ describe('Auth Client login', () => {
   it('should call onError on signer failure', async () => {
     mockSignerInstance.requestDelegation.mockRejectedValueOnce(new Error('mock error message'));
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     const onError = vi.fn();
     await client.login({ onError });
 
@@ -178,11 +187,30 @@ describe('Auth Client login', () => {
     expect(mockSignerInstance.closeChannel).toHaveBeenCalledOnce();
   });
 
+  it('should throw when login fails and no onError is provided', async () => {
+    mockSignerInstance.requestDelegation.mockRejectedValueOnce(new Error('mock throw message'));
+
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    await expect(client.login()).rejects.toThrow('mock throw message');
+    expect(mockSignerInstance.closeChannel).toHaveBeenCalledOnce();
+  });
+
+  it('should call onError instead of throwing when onError is provided', async () => {
+    mockSignerInstance.requestDelegation.mockRejectedValueOnce(new Error('callback error'));
+
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
+    const onError = vi.fn();
+
+    // Should NOT throw
+    await client.login({ onError });
+    expect(onError).toHaveBeenCalledWith('callback error');
+  });
+
   it('should call closeChannel even if onSuccess throws', async () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     const onError = vi.fn();
     const onSuccess = vi.fn(() => {
       throw new Error('onSuccess error');
@@ -197,11 +225,12 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
-    await client.login({
+    const client = await AuthClient.create({
       identityProvider: 'http://127.0.0.1',
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
+      idleOptions: { disableIdle: true },
     });
+    await client.login();
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
       url: 'http://127.0.0.1',
@@ -213,7 +242,7 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     await client.login();
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
@@ -226,18 +255,14 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    // We verify the Signer constructor receives derivationOrigin.
-    // Since we mock the whole module, we check PostMessageTransport was called
-    // and that login succeeds. The derivationOrigin is passed via the Signer
-    // constructor options, which we cannot directly inspect from the mock class.
-    // Instead we verify the login works end-to-end with derivationOrigin.
-    const client = await AuthClient.create();
-    const onSuccess = vi.fn();
-    await client.login({
+    // derivationOrigin is now set at create-time and passed via Signer constructor.
+    const client = await AuthClient.create({
       identityProvider: 'http://127.0.0.1',
       derivationOrigin: 'http://127.0.0.1:1234',
-      onSuccess,
+      idleOptions: { disableIdle: true },
     });
+    const onSuccess = vi.fn();
+    await client.login({ onSuccess });
 
     expect(onSuccess).toHaveBeenCalledOnce();
   });
@@ -246,30 +271,18 @@ describe('Auth Client login', () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     await client.login({ maxTimeToLive: BigInt(1000) });
 
     const callArgs = mockSignerInstance.requestDelegation.mock.calls[0][0];
     expect(callArgs.maxTimeToLive).toBe(BigInt(1000));
   });
 
-  it('should pass targets to requestDelegation', async () => {
-    const chain = await setupMockDelegation();
-    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
-
-    const targets = [Principal.fromText('aaaaa-aa')];
-    const client = await AuthClient.create();
-    await client.login({ targets });
-
-    const callArgs = mockSignerInstance.requestDelegation.mock.calls[0][0];
-    expect(callArgs.targets).toEqual(targets);
-  });
-
   it('should authenticate after a successful login', async () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
-    const client = await AuthClient.create();
+    const client = await AuthClient.create({ idleOptions: { disableIdle: true } });
     await client.login();
 
     expect(client.getIdentity().getPrincipal().isAnonymous()).toBe(false);
@@ -285,26 +298,32 @@ describe('Auth Client login', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage, keyType: 'Ed25519' });
+    const client = await AuthClient.create({
+      storage,
+      keyType: 'Ed25519',
+      idleOptions: { disableIdle: true },
+    });
     await client.login();
 
     // Should have set the delegation chain
     const delegationSetCalls = (storage.set as ReturnType<typeof vi.fn>).mock.calls.filter(
-      ([key]: [string]) => key === KEY_STORAGE_DELEGATION,
+      (call: unknown[]) => call[0] === KEY_STORAGE_DELEGATION,
     );
     expect(delegationSetCalls.length).toBeGreaterThan(0);
 
     // Should have persisted the key
     const keySetCalls = (storage.set as ReturnType<typeof vi.fn>).mock.calls.filter(
-      ([key]: [string]) => key === KEY_STORAGE_KEY,
+      (call: unknown[]) => call[0] === KEY_STORAGE_KEY,
     );
     // Key is set during create and again after login
     expect(keySetCalls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('should overwrite stored Ed25519 key with in-memory key on login', async () => {
-    const chain = await setupMockDelegation();
-    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
+  it('should generate a fresh key on each login call', async () => {
+    const chain1 = await setupMockDelegation();
+    const chain2 = await setupMockDelegation();
+    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain1);
+    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain2);
 
     const fakeStore: Record<string, string> = {};
     const storage: AuthClientStorage = {
@@ -317,69 +336,32 @@ describe('Auth Client login', () => {
       }),
     };
 
-    const client = await AuthClient.create({ storage, keyType: 'Ed25519' });
-
-    const initialKey = fakeStore[KEY_STORAGE_KEY];
-    expect(typeof initialKey).toBe('string');
-
-    // Simulate another tab overwriting the stored key
-    const overwrittenKey = 'overwritten-key-from-another-tab';
-    fakeStore[KEY_STORAGE_KEY] = overwrittenKey;
+    const client = await AuthClient.create({
+      storage,
+      keyType: 'Ed25519',
+      idleOptions: { disableIdle: true },
+    });
 
     await client.login();
-
-    expect(fakeStore[KEY_STORAGE_KEY]).toEqual(initialKey);
-    expect(fakeStore[KEY_STORAGE_KEY]).not.toEqual(overwrittenKey);
-  });
-
-  it('should overwrite stored ECDSA key pair with in-memory key on login', async () => {
-    const chain = await setupMockDelegation();
-    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
-
-    const fakeStore: Record<string, StoredKey> = {};
-    const storage: AuthClientStorage = {
-      remove: vi.fn(async (k: string) => {
-        delete fakeStore[k];
-      }),
-      get: vi.fn(async (k: string): Promise<StoredKey | null> => fakeStore[k] ?? null),
-      set: vi.fn(async (k: string, v: StoredKey) => {
-        fakeStore[k] = v;
-      }),
-    };
-
-    const client = await AuthClient.create({ storage }); // default ECDSA
-
-    const initialKeyPair = fakeStore[KEY_STORAGE_KEY] as CryptoKeyPair;
-    expect(initialKeyPair).toBeTruthy();
-    expect(initialKeyPair.publicKey).toBeDefined();
-    expect(initialKeyPair.privateKey).toBeDefined();
-
-    // Simulate another tab overwriting the stored key
-    const overwrittenKeyPair = (await ECDSAKeyIdentity.generate()).getKeyPair();
-    fakeStore[KEY_STORAGE_KEY] = overwrittenKeyPair;
+    const keyAfterFirstLogin = fakeStore[KEY_STORAGE_KEY];
 
     await client.login();
+    const keyAfterSecondLogin = fakeStore[KEY_STORAGE_KEY];
 
-    const restored = fakeStore[KEY_STORAGE_KEY] as CryptoKeyPair;
-    // Expect the same key references as initially stored
-    expect(restored.publicKey).toBe(initialKeyPair.publicKey);
-    expect(restored.privateKey).toBe(initialKeyPair.privateKey);
-    expect(restored.privateKey).not.toBe(overwrittenKeyPair.privateKey);
-    expect(restored.publicKey).not.toBe(overwrittenKeyPair.publicKey);
+    // A fresh key should have been generated for each login, so the stored keys should differ.
+    expect(keyAfterFirstLogin).not.toEqual(keyAfterSecondLogin);
   });
 
-  it('should use the loginOptions passed to the create method', async () => {
+  it('should use the identityProvider passed to the create method', async () => {
     const chain = await setupMockDelegation();
     mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
 
     const client = await AuthClient.create({
-      loginOptions: {
-        identityProvider: 'http://my-local-website.localhost:8080',
-        maxTimeToLive: BigInt(1000),
-      },
+      identityProvider: 'http://my-local-website.localhost:8080',
+      idleOptions: { disableIdle: true },
     });
 
-    await client.login();
+    await client.login({ maxTimeToLive: BigInt(1000) });
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
       url: 'http://my-local-website.localhost:8080',
@@ -388,27 +370,6 @@ describe('Auth Client login', () => {
 
     const callArgs = mockSignerInstance.requestDelegation.mock.calls[0][0];
     expect(callArgs.maxTimeToLive).toEqual(BigInt(1000));
-  });
-
-  it('should merge the loginOptions passed to the create method and the login method', async () => {
-    const chain = await setupMockDelegation();
-    mockSignerInstance.requestDelegation.mockResolvedValueOnce(chain);
-
-    const client = await AuthClient.create({
-      loginOptions: {
-        identityProvider: 'http://my-local-website.localhost:8080',
-        derivationOrigin: 'http://another-local-website.localhost:8080',
-      },
-    });
-
-    await client.login({
-      identityProvider: 'http://replaced.localhost:8080',
-    });
-
-    expect(mockPostMessageTransport).toHaveBeenCalledWith({
-      url: 'http://replaced.localhost:8080',
-      windowOpenerFeatures: undefined,
-    });
   });
 
   it('should log out after idle and reload the window by default', async () => {
@@ -559,7 +520,7 @@ describe('Migration from localstorage', () => {
       set: vi.fn(),
     };
 
-    await AuthClient.create({ storage });
+    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     // Key is stored during creation when none is provided
     expect(storage.set).toHaveBeenCalledTimes(1);
@@ -576,7 +537,7 @@ describe('Migration from localstorage', () => {
       set: vi.fn(),
     };
 
-    await AuthClient.create({ storage });
+    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     expect(storage.set).toHaveBeenCalledTimes(1);
   });
@@ -592,7 +553,7 @@ describe('Migration from localstorage', () => {
     await localStorage.set(KEY_STORAGE_DELEGATION, 'test');
     await localStorage.set(KEY_STORAGE_KEY, 'key');
 
-    await AuthClient.create({ storage });
+    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     expect(storage.set).toHaveBeenCalledTimes(3);
   });
@@ -642,7 +603,7 @@ describe('Migration from Ed25519Key', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage });
+    const client = await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     const identity = client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
@@ -672,7 +633,7 @@ describe('Migration from Ed25519Key', () => {
       set: vi.fn(),
     };
 
-    const client = await AuthClient.create({ storage });
+    const client = await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     const identity = client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
@@ -691,7 +652,7 @@ describe('Migration from Ed25519Key', () => {
         fakeStore[x] = y;
       }),
     };
-    await AuthClient.create({ storage });
+    await AuthClient.create({ storage, idleOptions: { disableIdle: true } });
 
     // It should have stored a cryptoKey
     expect(Object.keys(fakeStore[KEY_STORAGE_KEY])).toMatchInlineSnapshot(`
@@ -719,12 +680,20 @@ describe('Migration from Ed25519Key', () => {
       return key;
     });
 
-    const client1 = await AuthClient.create({ storage, keyType: 'Ed25519' });
+    const client1 = await AuthClient.create({
+      storage,
+      keyType: 'Ed25519',
+      idleOptions: { disableIdle: true },
+    });
     const identity1 = client1.getIdentity();
 
     // This auth client should find the Ed25519 key in the storage,
     // and not generate a new one
-    const client2 = await AuthClient.create({ storage, keyType: 'Ed25519' });
+    const client2 = await AuthClient.create({
+      storage,
+      keyType: 'Ed25519',
+      idleOptions: { disableIdle: true },
+    });
     const identity2 = client2.getIdentity();
 
     expect(generate).toHaveBeenCalledTimes(1);

--- a/tests/client/idle-manager.test.ts
+++ b/tests/client/idle-manager.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { IdleManager } from '../../src/client/idle-manager.ts';
 
 const MILLISECONDS_PER_SECOND = 1000;
@@ -11,6 +11,15 @@ beforeAll(() => {
     writable: true,
     value: { assign: vi.fn(), reload: vi.fn() },
   });
+});
+
+afterEach(() => {
+  // Tear down the singleton between tests so each test starts fresh.
+  try {
+    IdleManager.create().exit();
+  } catch {
+    // ignore if already torn down
+  }
 });
 
 describe('IdleManager', () => {
@@ -130,5 +139,30 @@ describe('IdleManager', () => {
     // simulate user being inactive for 9 minutes, plus the debounce
     vi.advanceTimersByTime(9 * MILLISECONDS_PER_MINUTE + scrollDebounce);
     expect(cb).toHaveBeenCalled();
+  });
+
+  it('should return the same instance on multiple create() calls', () => {
+    const instance1 = IdleManager.create();
+    const instance2 = IdleManager.create();
+    expect(instance1).toBe(instance2);
+  });
+
+  it('should return a fresh instance after exit()', () => {
+    const instance1 = IdleManager.create();
+    instance1.exit();
+    const instance2 = IdleManager.create();
+    expect(instance1).not.toBe(instance2);
+  });
+
+  it('should fire callbacks from multiple create() calls when idle', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    IdleManager.create({ onIdle: cb1 });
+    IdleManager.create({ onIdle: cb2 });
+
+    // simulate user being inactive for 10 minutes
+    vi.advanceTimersByTime(10 * MILLISECONDS_PER_MINUTE);
+    expect(cb1).toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Three improvements to `AuthClient` and `IdleManager`:

- **Fresh session key per login**: A new cryptographic key is generated on every `login()` call instead of reusing a stored key across sessions.
- **`login()` error handling**: `login()` now throws on failure by default. Passing `onError` opts into callback-style error handling instead (backwards compatible).
- **Singleton `IdleManager`**: Multiple `AuthClient` instances share a single `IdleManager`, avoiding duplicate DOM listeners and timers.
- **Transport options moved to constructor**: `identityProvider`, `derivationOrigin`, and `windowOpenerFeatures` moved from `AuthClientLoginOptions` to `AuthClientCreateOptions`.

BREAKING CHANGE:
- `identityProvider`, `derivationOrigin`, and `windowOpenerFeatures` moved from `AuthClientLoginOptions` to `AuthClientCreateOptions`
- `loginOptions` field removed from `AuthClientCreateOptions`

---
Prev: #75 | Next: #81