### PR TITLE
feat: update README and quick-start for new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,24 @@ Here's a simple example of how to use the `@icp-sdk/auth` package to authenticat
 ```typescript
 import { AuthClient } from '@icp-sdk/auth/client';
 
-const identityProvider = 'https://id.ai/';
+const authClient = new AuthClient();
 
-const authClient = await AuthClient.create();
-const identity = authClient.getIdentity(); // At this point, you'll get a Principal.anonymous()
-
-async function onSuccess() {
-  console.log('Login successful');
-
-  const identity = authClient.getIdentity(); // At this point, you'll get an authenticated identity
-  console.log(authClient.isAuthenticated()); // true
+// Check for an existing session (synchronous)
+if (authClient.isAuthenticated()) {
+  const identity = await authClient.getIdentity();
+  console.log('Restored session:', identity.getPrincipal().toString());
 }
 
-await authClient.login({
-  identityProvider,
-  onSuccess,
-});
+// Log in
+try {
+  await authClient.login();
+  const identity = await authClient.getIdentity();
+  console.log('Logged in:', identity.getPrincipal().toString());
+} catch (error) {
+  console.error('Login failed:', error);
+}
 
-// later in your app
+// Log out
 await authClient.logout();
 ```
 

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -16,35 +16,35 @@ import { HttpAgent } from '@icp-sdk/core/agent';
 const network = 'ic'; // typically, this value is read from the environment (e.g. process.env.DFX_NETWORK)
 const identityProvider =
   network === 'ic'
-    ? 'https://id.ai/' // Mainnet
-    : 'http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:4943'; // Local
+    ? 'https://id.ai/authorize' // Mainnet
+    : 'http://id.ai.localhost:8000'; // default name mapping set by icp-cli when ii is enabled
 
-const authClient = await AuthClient.create();
-const identity = authClient.getIdentity(); // At this point, you'll get a Principal.anonymous()
-console.log(authClient.isAuthenticated()); // false
+const authClient = new AuthClient({ identityProvider });
+
+// Check for an existing session (synchronous)
+if (authClient.isAuthenticated()) {
+  const identity = await authClient.getIdentity();
+  console.log('Restored session:', identity.getPrincipal().toString());
+}
 
 const canisterId = Principal.fromText('uqqxf-5h777-77774-qaaaa-cai');
 const agent = await HttpAgent.create({
   host: 'https://icp-api.io',
 });
 
-async function onSuccess() {
-  console.log('Login successful');
-
-  const identity = authClient.getIdentity(); // At this point, you'll get an authenticated identity
-  console.log(authClient.isAuthenticated()); // true
-  agent.replaceIdentity(identity);
-
-  // this call will be authenticated
-  await agent.call(canisterId, {
-    methodName: 'greet',
-    arg: IDL.encode([IDL.Text], ['world']),
-  });
+try {
+  await authClient.login();
+} catch (error) {
+  console.error('Login failed:', error);
 }
 
-await authClient.login({
-  identityProvider,
-  onSuccess,
+const identity = await authClient.getIdentity();
+agent.replaceIdentity(identity);
+
+// this call will be authenticated
+await agent.call(canisterId, {
+  methodName: 'greet',
+  arg: IDL.encode([IDL.Text], ['world']),
 });
 
 // later in your app

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -125,6 +125,10 @@ export interface AuthClientLoginOptions {
   onError?: OnErrorFunc;
 }
 
+// ---------------------------------------------------------------------------
+// Free functions – persistence helpers
+// ---------------------------------------------------------------------------
+
 /**
  * Generates a fresh session key of the given type.
  */
@@ -256,6 +260,10 @@ async function migrateFromLocalStorage(
     console.error(`error while attempting to recover localstorage: ${error}`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// AuthClient
+// ---------------------------------------------------------------------------
 
 /**
  * Tool to manage authentication and identity


### PR DESCRIPTION
Updates documentation to match the new API:

- README: `new AuthClient()` instead of `await AuthClient.create()`, try/catch for login, sync `isAuthenticated()`
- Quick start: same updates plus `identityProvider` moved to constructor

---
Prev: #81 | Next: #83