### PR TITLE
feat: one-click OpenID sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ try {
 await authClient.logout();
 ```
 
+### One-Click OpenID Sign-In
+
+Skip the Internet Identity authentication method screen and offer sign-in options like Google directly in your app:
+
+```typescript
+const authClient = new AuthClient({
+  openIdProvider: 'google', // or 'apple' or 'microsoft'
+});
+
+await authClient.login();
+```
+
 Additional documentation can be found [here](https://js.icp.build/auth/latest/).
 
 ## Contributing

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -17,7 +17,7 @@ const network = 'ic'; // typically, this value is read from the environment (e.g
 const identityProvider =
   network === 'ic'
     ? 'https://id.ai/authorize' // Mainnet
-    : 'http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:4943'; // Local
+    : 'http://id.ai.localhost:8000'; // default name mapping set by icp-cli when ii is enabled
 
 const authClient = new AuthClient({ identityProvider });
 

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -17,7 +17,7 @@ const network = 'ic'; // typically, this value is read from the environment (e.g
 const identityProvider =
   network === 'ic'
     ? 'https://id.ai/authorize' // Mainnet
-    : 'http://id.ai.localhost:8000'; // default name mapping set by icp-cli when ii is enabled
+    : 'http://rdmx6-jaaaa-aaaaa-aaadq-cai.localhost:4943'; // Local
 
 const authClient = new AuthClient({ identityProvider });
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -38,6 +38,14 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 // isAuthenticated() can answer synchronously without hitting IndexedDB.
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
+export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
+
+const OPENID_PROVIDER_URLS: Record<OpenIdProvider, string> = {
+  google: 'https://accounts.google.com',
+  apple: 'https://appleid.apple.com',
+  microsoft: 'https://login.microsoftonline.com/{tid}/v2.0',
+};
+
 /**
  * List of options for creating an {@link AuthClient}.
  */
@@ -84,6 +92,13 @@ export interface AuthClientCreateOptions {
    * @example "toolbar=0,location=0,menubar=0,width=500,height=500,left=100,top=100"
    */
   windowOpenerFeatures?: string;
+
+  /**
+   * OpenID provider for one-click sign-in. When set, the identity provider
+   * URL includes an `openid` search param so the user authenticates via
+   * the chosen provider (e.g. Google) instead of seeing Internet Identity directly.
+   */
+  openIdProvider?: OpenIdProvider;
 }
 
 export interface IdleOptions extends IdleManagerOptions {
@@ -124,10 +139,6 @@ export interface AuthClientLoginOptions {
    */
   onError?: OnErrorFunc;
 }
-
-// ---------------------------------------------------------------------------
-// Free functions – persistence helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Generates a fresh session key of the given type.
@@ -304,10 +315,15 @@ export class AuthClient {
     this.#createOptions = options;
 
     // Create transport and signer from create-time options so they are reusable across logins.
-    const identityProviderUrl = options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT;
+    const identityProviderUrl = new URL(
+      options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
+    );
+    if (options.openIdProvider) {
+      identityProviderUrl.searchParams.set('openid', OPENID_PROVIDER_URLS[options.openIdProvider]);
+    }
 
     const transport = new PostMessageTransport({
-      url: identityProviderUrl,
+      url: identityProviderUrl.toString(),
       windowOpenerFeatures: options.windowOpenerFeatures,
     });
 

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -165,6 +165,38 @@ describe('Auth Client', () => {
   });
 });
 
+describe('OpenID provider', () => {
+  it.each([
+    ['google', 'https://accounts.google.com'],
+    ['apple', 'https://appleid.apple.com'],
+    ['microsoft', 'https://login.microsoftonline.com/{tid}/v2.0'],
+  ] as const)('should pass openid=%s search param to the transport', (provider, expectedUrl) => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({ openIdProvider: provider, idleOptions: { disableIdle: true } });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.get('openid')).toBe(expectedUrl);
+  });
+
+  it('should not include openid search param when openIdProvider is not set', () => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({ idleOptions: { disableIdle: true } });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.searchParams.has('openid')).toBe(false);
+  });
+
+  it('should add openid param to a custom identityProvider URL', () => {
+    mockPostMessageTransport.mockClear();
+    new AuthClient({
+      identityProvider: 'http://localhost:4943',
+      openIdProvider: 'apple',
+      idleOptions: { disableIdle: true },
+    });
+    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    expect(url.origin).toBe('http://localhost:4943');
+    expect(url.searchParams.get('openid')).toBe('https://appleid.apple.com');
+  });
+});
+
 describe('Auth Client login', () => {
   function setupMockDelegation() {
     const key = Ed25519KeyIdentity.generate();
@@ -246,7 +278,7 @@ describe('Auth Client login', () => {
     await client.login();
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
-      url: 'http://127.0.0.1',
+      url: 'http://127.0.0.1/',
       windowOpenerFeatures: 'toolbar=0,location=0,menubar=0',
     });
   });
@@ -377,7 +409,7 @@ describe('Auth Client login', () => {
     await client.login({ maxTimeToLive: BigInt(1000) });
 
     expect(mockPostMessageTransport).toHaveBeenCalledWith({
-      url: 'http://my-local-website.localhost:8080',
+      url: 'http://my-local-website.localhost:8080/',
       windowOpenerFeatures: undefined,
     });
 


### PR DESCRIPTION
Adds support for one-click sign-in via OpenID providers. When `openIdProvider` is set on `AuthClientCreateOptions`, the identity provider URL includes an `openid` search param, allowing the user to skip the Internet Identity authentication method screen and authenticate via Google, Apple, or Microsoft directly.

Supported providers:
- `'google'` → `https://accounts.google.com`
- `'apple'` → `https://appleid.apple.com`
- `'microsoft'` → `https://login.microsoftonline.com/{tid}/v2.0`

```typescript
const authClient = new AuthClient({
  openIdProvider: 'google',
});
await authClient.login();
```

---
Prev: #82 | Next: #84