### PR TITLE
ci: add BOT_APPROVED_FILES config

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,2 @@
+# List of approved files that can be changed by a bot via an automated PR
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- Adds `.github/repo_policies/BOT_APPROVED_FILES` with `CHANGELOG.md`
- The `check-repo-policies` workflow requires this file to exist on the default branch, otherwise the `check_bot_approved_files` check fails with a 404

## Test plan
- [ ] Verify the `check-repo-policies` CI check passes after merge