### PR TITLE
ci: approve .cz.toml and package.json for bot PRs

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,2 +1,4 @@
 # List of approved files that can be changed by a bot via an automated PR
 CHANGELOG.md
+.cz.toml
+package.json


### PR DESCRIPTION
## Summary
- Adds `.cz.toml` and `package.json` to `.github/repo_policies/BOT_APPROVED_FILES`
- These files are updated by the release bot and need to be approved for the `check-repo-policies` workflow

## Test plan
- [ ] Verify the `check-repo-policies` CI check passes on release bot PRs after merge