### PR TITLE
fix: include id in requestAttributes JSON-RPC request

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ try {
   const signInPromise = authClient.signIn();
   const attributesPromise = authClient.requestAttributes({ keys: ['email'], nonce });
 
-  await signInPromise;
+  const identity = await signInPromise;
   const { data, signature } = await attributesPromise;
 
   // wrap the identity so the signed attributes are included in the canister call
   const identityWithAttributes = new AttributesIdentity({
-    inner: await authClient.getIdentity(),
+    inner: identity,
     attributes: { data, signature },
     signer: { canisterId: Principal.fromText('rdmx6-jaaaa-aaaaa-aaadq-cai') }, // Internet Identity canister ID
   });

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here's a registration flow where the backend needs the user's email:
 import { AuthClient } from '@icp-sdk/auth/client';
 import { AttributesIdentity } from '@icp-sdk/core/identity';
 import { HttpAgent, Actor } from '@icp-sdk/core/agent';
+import { Principal } from '@icp-sdk/core/principal';
 
 const authClient = new AuthClient();
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -273,6 +273,7 @@ export class AuthClient {
 
     const response = await this.#signer.sendRequest({
       jsonrpc: '2.0',
+      id: globalThis.crypto.randomUUID(),
       method: 'ii-icrc3-attributes',
       params: { keys: params.keys, nonce: toBase64(nonceBytes) },
     });

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -1,4 +1,5 @@
 import { DelegationChain, Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import { Principal } from '@icp-sdk/core/principal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthClient } from '../../src/client/auth-client.ts';
 import { IdleManager } from '../../src/client/idle-manager.ts';
@@ -9,59 +10,93 @@ import {
   KEY_STORAGE_KEY,
   LocalStorage,
 } from '../../src/client/storage.ts';
+import { FakeTransport } from './fake-transport.ts';
 
-// Mock @icp-sdk/signer so signIn() doesn't open real windows.
-const { mockSignerInstance, mockPostMessageTransport } = vi.hoisted(() => ({
-  mockSignerInstance: {
-    openChannel: vi.fn(),
-    closeChannel: vi.fn(),
-    requestDelegation: vi.fn(),
-    sendRequest: vi.fn(),
-  },
-  mockPostMessageTransport: vi.fn(),
-}));
+// Swap `PostMessageTransport` for `FakeTransport` so `AuthClient` uses the real
+// `Signer` over an in-memory transport — no window is opened and nothing about
+// the signer's JSON-RPC correlation is faked.
+vi.mock('@icp-sdk/signer/web', async () => {
+  const { FakeTransport } = await import('./fake-transport.ts');
+  return { PostMessageTransport: FakeTransport };
+});
 
-vi.mock('@icp-sdk/signer', () => ({
-  Signer: class {
-    openChannel = mockSignerInstance.openChannel;
-    closeChannel = mockSignerInstance.closeChannel;
-    requestDelegation = mockSignerInstance.requestDelegation;
-    sendRequest = mockSignerInstance.sendRequest;
-  },
-}));
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
 
-vi.mock('@icp-sdk/signer/web', () => ({
-  PostMessageTransport: mockPostMessageTransport,
-}));
-
-/**
- * Helper: creates a valid DelegationChain for testing.
- */
 async function createTestDelegation(key: Ed25519KeyIdentity, expiration?: Date) {
   const exp = expiration ?? new Date(Date.now() + 24 * 60 * 60 * 1000); // 1 day from now
   return DelegationChain.create(key, key.getPublicKey(), exp);
 }
 
+function encodeDelegationChainResponse(chain: DelegationChain) {
+  return {
+    publicKey: toBase64(new Uint8Array(chain.publicKey)),
+    signerDelegation: chain.delegations.map((sd) => ({
+      delegation: {
+        pubkey: toBase64(new Uint8Array(sd.delegation.pubkey)),
+        expiration: sd.delegation.expiration.toString(),
+        targets: sd.delegation.targets?.map((t) => t.toText()),
+      },
+      signature: toBase64(new Uint8Array(sd.signature)),
+    })),
+  };
+}
+
+type JsonRpcBody =
+  | { result: unknown }
+  | { error: { code: number; message: string; data?: unknown } };
+
+// Shared default bodies — declared as constants so both helpers use a
+// parameter-default form consistently. `DelegationChain.create` is async, so
+// top-level `await` is used; `await` isn't allowed inside param defaults.
+const DEFAULT_SIGN_IN_BODY: JsonRpcBody = {
+  result: encodeDelegationChainResponse(await createTestDelegation(Ed25519KeyIdentity.generate())),
+};
+
+const DEFAULT_REQUEST_ATTRIBUTES_BODY: JsonRpcBody = {
+  result: { data: btoa('hello'), signature: btoa('sig') },
+};
+
 /**
- * Helper: configures the mocked Signer so requestDelegation resolves with a test chain.
+ * Registers an `icrc34_delegation` handler that returns the given body.
+ * Defaults to a valid delegation chain so `signIn()` resolves successfully.
  */
-async function mockSignerForSignIn() {
-  const key = Ed25519KeyIdentity.generate();
-  const chain = await createTestDelegation(key);
-  mockSignerInstance.openChannel.mockResolvedValue(undefined);
-  mockSignerInstance.closeChannel.mockResolvedValue(undefined);
-  mockSignerInstance.requestDelegation.mockResolvedValue(chain);
-  return { key, chain };
+function handleSignIn(transport: FakeTransport, body: JsonRpcBody = DEFAULT_SIGN_IN_BODY): void {
+  transport.onRequest((req) => {
+    if (req.method !== 'icrc34_delegation') return;
+    if (req.id === undefined || req.id === null) return;
+    return { jsonrpc: '2.0', id: req.id, ...body };
+  });
+}
+
+/**
+ * Registers an `ii-icrc3-attributes` handler that returns the given body.
+ * Defaults to a valid success response with placeholder data and signature.
+ */
+function handleRequestAttributes(
+  transport: FakeTransport,
+  body: JsonRpcBody = DEFAULT_REQUEST_ATTRIBUTES_BODY,
+): void {
+  transport.onRequest((req) => {
+    if (req.method !== 'ii-icrc3-attributes') return;
+    if (req.id === undefined || req.id === null) return;
+    return { jsonrpc: '2.0', id: req.id, ...body };
+  });
 }
 
 beforeEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   localStorage.clear();
-  mockSignerInstance.openChannel.mockReset();
-  mockSignerInstance.closeChannel.mockReset();
-  mockSignerInstance.requestDelegation.mockReset();
-  mockSignerInstance.sendRequest.mockReset();
+  FakeTransport.reset();
+  // `IdleManager.exit()` runs all registered callbacks on teardown (see
+  // idle-manager.ts#exit), including the default `location.reload()` callback
+  // from signed-in tests. Stub globally so afterEach teardown doesn't trigger
+  // jsdom's "Not implemented: navigation to another Document" warning.
+  vi.stubGlobal('location', { reload: vi.fn() });
 });
 
 afterEach(async () => {
@@ -119,17 +154,20 @@ describe('AuthClient', () => {
     ['apple', 'https://appleid.apple.com'],
     ['microsoft', 'https://login.microsoftonline.com/{tid}/v2.0'],
   ] as const)('should pass openid=%s search param to the transport', (provider, expectedUrl) => {
-    mockPostMessageTransport.mockClear();
     new AuthClient({ openIdProvider: provider });
-    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    const url = new URL(FakeTransport.last().options.url ?? '');
     expect(url.searchParams.get('openid')).toBe(expectedUrl);
   });
 
   it('should not include openid search param when openIdProvider is not set', () => {
-    mockPostMessageTransport.mockClear();
     new AuthClient();
-    const url = new URL(mockPostMessageTransport.mock.calls[0][0].url);
+    const url = new URL(FakeTransport.last().options.url ?? '');
     expect(url.searchParams.has('openid')).toBe(false);
+  });
+
+  it('should forward windowOpenerFeatures to the transport', () => {
+    new AuthClient({ windowOpenerFeatures: 'width=500,height=600' });
+    expect(FakeTransport.last().options.windowOpenerFeatures).toBe('width=500,height=600');
   });
 
   it('should not set up an idle timer if the disable option is set', () => {
@@ -145,41 +183,66 @@ describe('AuthClient', () => {
 
 describe('AuthClient signIn', () => {
   it('should return the authenticated identity', async () => {
-    await mockSignerForSignIn();
     const client = new AuthClient();
+    handleSignIn(FakeTransport.last());
     const identity = await client.signIn();
     expect(identity.getPrincipal().toString()).toBeTruthy();
   });
 
   it('should set up an idle manager after sign-in', async () => {
-    await mockSignerForSignIn();
     const client = new AuthClient();
+    handleSignIn(FakeTransport.last());
     await client.signIn();
     expect(client.idleManager).toBeDefined();
   });
 
   it('should not set up an idle manager if disableIdle is set', async () => {
-    await mockSignerForSignIn();
     const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
     expect(client.idleManager).toBeUndefined();
   });
 
-  it('should throw on sign-in failure', async () => {
-    mockSignerInstance.openChannel.mockRejectedValue(new Error('connection failed'));
-
+  it('should propagate signer errors from the delegation request', async () => {
     const client = new AuthClient();
+    handleSignIn(FakeTransport.last(), {
+      error: { code: -1, message: 'connection failed' },
+    });
     await expect(client.signIn()).rejects.toThrow('connection failed');
   });
 
+  it('should forward targets and maxTimeToLive to the delegation request', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleSignIn(transport);
+
+    const target = Principal.fromText('aaaaa-aa');
+    await client.signIn({ targets: [target], maxTimeToLive: 1_000_000n });
+
+    const req = transport.requests[0];
+    expect(req.method).toBe('icrc34_delegation');
+    expect(req.params?.targets).toEqual([target.toText()]);
+    expect(req.params?.maxTimeToLive).toBe('1000000');
+  });
+
+  it('should forward derivationOrigin on every request as icrc95DerivationOrigin', async () => {
+    const client = new AuthClient({ derivationOrigin: 'https://example.com' });
+    const transport = FakeTransport.last();
+    handleSignIn(transport);
+
+    await client.signIn();
+
+    expect(transport.requests[0].params?.icrc95DerivationOrigin).toBe('https://example.com');
+  });
+
   it('should persist delegation and key after sign-in', async () => {
-    await mockSignerForSignIn();
     const storage: AuthClientStorage = {
       remove: vi.fn(),
       get: vi.fn().mockResolvedValue(null),
       set: vi.fn(),
     };
     const client = new AuthClient({ storage });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
 
     expect(storage.set).toHaveBeenCalledWith(KEY_STORAGE_DELEGATION, expect.any(String));
@@ -187,7 +250,6 @@ describe('AuthClient signIn', () => {
   });
 
   it('should generate a fresh key for each sign-in', async () => {
-    await mockSignerForSignIn();
     const storedKeys: unknown[] = [];
     const storage: AuthClientStorage = {
       remove: vi.fn(),
@@ -197,6 +259,7 @@ describe('AuthClient signIn', () => {
       }),
     };
     const client = new AuthClient({ storage, keyType: 'Ed25519' });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
     await client.signIn();
 
@@ -205,16 +268,16 @@ describe('AuthClient signIn', () => {
   });
 
   it('should set the localStorage expiration flag after sign-in', async () => {
-    await mockSignerForSignIn();
     const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    handleSignIn(FakeTransport.last());
     expect(client.isAuthenticated()).toBe(false);
     await client.signIn();
     expect(client.isAuthenticated()).toBe(true);
   });
 
   it('should clear the localStorage expiration flag on logout', async () => {
-    await mockSignerForSignIn();
     const client = new AuthClient({ idleOptions: { disableIdle: true } });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
     expect(client.isAuthenticated()).toBe(true);
     await client.logout();
@@ -224,9 +287,6 @@ describe('AuthClient signIn', () => {
 
 describe('AuthClient idle behavior', () => {
   it('should log out after idle and reload the window by default', async () => {
-    vi.stubGlobal('location', { reload: vi.fn() });
-
-    await mockSignerForSignIn();
     const storage: AuthClientStorage = {
       remove: vi.fn(),
       get: vi.fn().mockResolvedValue(null),
@@ -236,6 +296,7 @@ describe('AuthClient idle behavior', () => {
       storage,
       idleOptions: { idleTimeout: 1000 },
     });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
 
     expect(storage.remove).not.toHaveBeenCalled();
@@ -244,12 +305,10 @@ describe('AuthClient idle behavior', () => {
 
     expect(storage.remove).toHaveBeenCalled();
     expect(window.location.reload).toHaveBeenCalled();
+    expect(client.isAuthenticated()).toBe(false);
   });
 
   it('should not reload the page if the default callback is disabled', async () => {
-    vi.stubGlobal('location', { reload: vi.fn() });
-
-    await mockSignerForSignIn();
     const storage: AuthClientStorage = {
       remove: vi.fn(),
       get: vi.fn().mockResolvedValue(null),
@@ -259,6 +318,7 @@ describe('AuthClient idle behavior', () => {
       storage,
       idleOptions: { idleTimeout: 1000, disableDefaultIdleCallback: true },
     });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
 
     await new Promise((r) => setTimeout(r, 1100));
@@ -268,13 +328,11 @@ describe('AuthClient idle behavior', () => {
   });
 
   it('should call onIdle instead of the default behavior when provided', async () => {
-    vi.stubGlobal('location', { reload: vi.fn() });
-
-    await mockSignerForSignIn();
     const idleCb = vi.fn();
     const client = new AuthClient({
       idleOptions: { idleTimeout: 1000, onIdle: idleCb },
     });
+    handleSignIn(FakeTransport.last());
     await client.signIn();
 
     // Wait for the idle timeout to fire (real timers).
@@ -373,8 +431,7 @@ describe('Migration from localStorage', () => {
     };
 
     new AuthClient({ storage });
-    // Wait for hydration
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0)); // wait for hydration
 
     // No migration should have occurred (no set calls for delegation/key)
     expect(storage.set).not.toHaveBeenCalled();
@@ -392,8 +449,7 @@ describe('Migration from localStorage', () => {
     await legacyStorage.set(KEY_STORAGE_KEY, 'key');
 
     new AuthClient({ storage });
-    // Wait for hydration
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0)); // wait for hydration
 
     expect(storage.set).toHaveBeenCalledWith(KEY_STORAGE_DELEGATION, 'test');
     expect(storage.set).toHaveBeenCalledWith(KEY_STORAGE_KEY, 'key');
@@ -402,82 +458,111 @@ describe('Migration from localStorage', () => {
 
 describe('AuthClient requestAttributes', () => {
   it('should send a JSON-RPC request and return decoded data and signature', async () => {
-    const data = btoa('hello');
-    const signature = btoa('sig');
-    mockSignerInstance.sendRequest.mockResolvedValue({
-      jsonrpc: '2.0',
-      id: null,
-      result: { data, signature },
-    });
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleRequestAttributes(transport);
 
     const nonce = new Uint8Array(32).fill(1);
-    const client = new AuthClient();
     const result = await client.requestAttributes({ keys: ['email', 'name'], nonce });
 
-    const callArgs = mockSignerInstance.sendRequest.mock.calls[0][0];
-    expect(callArgs.method).toBe('ii-icrc3-attributes');
-    expect(callArgs.params.keys).toEqual(['email', 'name']);
-    expect(callArgs.params.nonce).toBe(btoa(String.fromCharCode(...nonce)));
+    const sent = transport.requests[0];
+    expect(sent.method).toBe('ii-icrc3-attributes');
+    expect(sent.params?.keys).toEqual(['email', 'name']);
+    expect(sent.params?.nonce).toBe(btoa(String.fromCharCode(...nonce)));
     expect(Array.from(result.data)).toEqual(Array.from(new TextEncoder().encode('hello')));
     expect(Array.from(result.signature)).toEqual(Array.from(new TextEncoder().encode('sig')));
   });
 
   it('should use a provided nonce', async () => {
-    mockSignerInstance.sendRequest.mockResolvedValue({
-      jsonrpc: '2.0',
-      id: null,
-      result: { data: btoa('hello'), signature: btoa('sig') },
-    });
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleRequestAttributes(transport);
 
     const nonce = new Uint8Array(32).fill(42);
-    const client = new AuthClient();
     await client.requestAttributes({ keys: ['email'], nonce });
 
-    const callArgs = mockSignerInstance.sendRequest.mock.calls[0][0];
-    expect(callArgs.params.nonce).toBe(btoa(String.fromCharCode(...nonce)));
+    expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonce)));
   });
 
   it('should forward different nonces as distinct base64 values', async () => {
-    mockSignerInstance.sendRequest.mockResolvedValue({
-      jsonrpc: '2.0',
-      id: null,
-      result: { data: btoa('a'), signature: btoa('b') },
-    });
-
     const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleRequestAttributes(transport);
+
     await client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(1) });
     await client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(2) });
 
-    const nonce1 = mockSignerInstance.sendRequest.mock.calls[0][0].params.nonce;
-    const nonce2 = mockSignerInstance.sendRequest.mock.calls[1][0].params.nonce;
-    expect(nonce1).not.toBe(nonce2);
+    expect(transport.requests[0].params?.nonce).not.toBe(transport.requests[1].params?.nonce);
   });
 
   it('should throw when the response contains an error', async () => {
-    mockSignerInstance.sendRequest.mockResolvedValue({
-      jsonrpc: '2.0',
-      id: null,
+    const client = new AuthClient();
+    handleRequestAttributes(FakeTransport.last(), {
       error: { code: -1, message: 'not supported' },
     });
 
     const nonce = new Uint8Array(32).fill(1);
-    const client = new AuthClient();
     await expect(client.requestAttributes({ keys: ['email'], nonce })).rejects.toThrow(
       'not supported',
     );
   });
 
   it('should throw when the response is missing data or signature', async () => {
-    mockSignerInstance.sendRequest.mockResolvedValue({
-      jsonrpc: '2.0',
-      id: null,
-      result: { data: btoa('hello') },
-    });
+    const client = new AuthClient();
+    handleRequestAttributes(FakeTransport.last(), { result: { data: btoa('hello') } });
 
     const nonce = new Uint8Array(32).fill(1);
-    const client = new AuthClient();
     await expect(client.requestAttributes({ keys: ['email'], nonce })).rejects.toThrow(
       'Invalid response: missing data or signature',
     );
+  });
+});
+
+describe('AuthClient signIn + requestAttributes', () => {
+  it('should resolve both when issued in parallel', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleSignIn(transport);
+    handleRequestAttributes(transport);
+
+    const [identity, attributes] = await Promise.all([
+      client.signIn(),
+      client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(1) }),
+    ]);
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+    expect(Array.from(attributes.data)).toEqual(Array.from(new TextEncoder().encode('hello')));
+  });
+
+  it('should resolve requestAttributes after a completed signIn', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleSignIn(transport);
+    handleRequestAttributes(transport);
+
+    const identity = await client.signIn();
+    const attributes = await client.requestAttributes({
+      keys: ['email'],
+      nonce: new Uint8Array(32).fill(1),
+    });
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+    expect(Array.from(attributes.data)).toEqual(Array.from(new TextEncoder().encode('hello')));
+  });
+
+  it('should resolve signIn after a completed requestAttributes', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleSignIn(transport);
+    handleRequestAttributes(transport);
+
+    const attributes = await client.requestAttributes({
+      keys: ['email'],
+      nonce: new Uint8Array(32).fill(1),
+    });
+    const identity = await client.signIn();
+
+    expect(Array.from(attributes.data)).toEqual(Array.from(new TextEncoder().encode('hello')));
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
   });
 });

--- a/tests/client/fake-transport.test.ts
+++ b/tests/client/fake-transport.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FakeTransport } from './fake-transport.ts';
+
+afterEach(() => {
+  FakeTransport.reset();
+});
+
+describe('FakeTransport', () => {
+  describe('instance tracking', () => {
+    it('should record instances in construction order', () => {
+      const a = new FakeTransport({ url: 'a' });
+      const b = new FakeTransport({ url: 'b' });
+      expect(FakeTransport.instances).toEqual([a, b]);
+      expect(FakeTransport.last()).toBe(b);
+    });
+
+    it('should throw from last() when no instance exists', () => {
+      expect(() => FakeTransport.last()).toThrow('No FakeTransport instance exists');
+    });
+
+    it('should clear instances on reset', () => {
+      new FakeTransport();
+      FakeTransport.reset();
+      expect(FakeTransport.instances).toEqual([]);
+    });
+
+    it('should capture constructor options', () => {
+      const t = new FakeTransport({ url: 'https://example.com', windowOpenerFeatures: 'w=1' });
+      expect(t.options).toEqual({ url: 'https://example.com', windowOpenerFeatures: 'w=1' });
+    });
+  });
+
+  describe('send', () => {
+    it('should record every request', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+      await channel.send({ jsonrpc: '2.0', id: '2', method: 'bar' });
+      expect(t.requests.map((r) => r.method)).toEqual(['foo', 'bar']);
+    });
+
+    it('should not dispatch when id is undefined (notification)', async () => {
+      const t = new FakeTransport();
+      const handler = vi.fn();
+      t.onRequest(handler);
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', method: 'foo' });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch when id is null', async () => {
+      const t = new FakeTransport();
+      const handler = vi.fn();
+      t.onRequest(handler);
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: null, method: 'foo' });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should invoke the handler and dispatch its response for an id-ful request', async () => {
+      const t = new FakeTransport();
+      t.onRequest((req) => ({
+        jsonrpc: '2.0',
+        id: req.id!,
+        result: `for-${req.method}`,
+      }));
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: 'abc', method: 'foo' });
+
+      expect(listener).toHaveBeenCalledWith({ jsonrpc: '2.0', id: 'abc', result: 'for-foo' });
+    });
+
+    it('should not dispatch when no handler is registered', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should try handlers in order and stop at the first non-undefined response', async () => {
+      const t = new FakeTransport();
+      const a = vi.fn((req) =>
+        req.method === 'a' ? { jsonrpc: '2.0' as const, id: req.id!, result: 'a' } : undefined,
+      );
+      const b = vi.fn((req) =>
+        req.method === 'b' ? { jsonrpc: '2.0' as const, id: req.id!, result: 'b' } : undefined,
+      );
+      const c = vi.fn(() => ({ jsonrpc: '2.0' as const, id: null, result: 'c' }));
+      t.onRequest(a);
+      t.onRequest(b);
+      t.onRequest(c);
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'a' });
+      expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ result: 'a' }));
+      expect(b).not.toHaveBeenCalled();
+      expect(c).not.toHaveBeenCalled();
+
+      await channel.send({ jsonrpc: '2.0', id: '2', method: 'b' });
+      expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ result: 'b' }));
+      expect(c).not.toHaveBeenCalled();
+    });
+
+    it('should not dispatch when every handler returns undefined', async () => {
+      const t = new FakeTransport();
+      t.onRequest(() => undefined);
+      t.onRequest(() => undefined);
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should await async handlers before dispatching', async () => {
+      const t = new FakeTransport();
+      t.onRequest(async (req) => {
+        await Promise.resolve();
+        return { jsonrpc: '2.0', id: req.id!, result: 'async' };
+      });
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+
+      expect(listener).toHaveBeenCalledWith({ jsonrpc: '2.0', id: '1', result: 'async' });
+    });
+
+    it('should reject send on a closed channel', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      await channel.close();
+
+      await expect(channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' })).rejects.toThrow(
+        'closed',
+      );
+    });
+  });
+
+  describe('addEventListener', () => {
+    it('should return an unsubscribe for response listeners', async () => {
+      const t = new FakeTransport();
+      t.onRequest((req) => ({ jsonrpc: '2.0', id: req.id!, result: 'ok' }));
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      const unsubscribe = channel.addEventListener('response', listener);
+      unsubscribe();
+
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should return an unsubscribe for close listeners', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      const unsubscribe = channel.addEventListener('close', listener);
+      unsubscribe();
+
+      await channel.close();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close', () => {
+    it('should mark the channel closed and notify listeners', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('close', listener);
+
+      await channel.close();
+
+      expect(channel.closed).toBe(true);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be idempotent', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('close', listener);
+
+      await channel.close();
+      await channel.close();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handler registration', () => {
+    it('should pick up handlers registered after establishChannel', async () => {
+      const t = new FakeTransport();
+      const channel = await t.establishChannel();
+      const listener = vi.fn();
+      channel.addEventListener('response', listener);
+
+      t.onRequest((req) => ({ jsonrpc: '2.0', id: req.id!, result: 'late' }));
+      await channel.send({ jsonrpc: '2.0', id: '1', method: 'foo' });
+
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ result: 'late' }));
+    });
+
+    it('should share handlers across concurrent channels', async () => {
+      const t = new FakeTransport();
+      t.onRequest((req) => ({ jsonrpc: '2.0', id: req.id!, result: 'shared' }));
+      const [ch1, ch2] = await Promise.all([t.establishChannel(), t.establishChannel()]);
+      const l1 = vi.fn();
+      const l2 = vi.fn();
+      ch1.addEventListener('response', l1);
+      ch2.addEventListener('response', l2);
+
+      await Promise.all([
+        ch1.send({ jsonrpc: '2.0', id: 'a', method: 'foo' }),
+        ch2.send({ jsonrpc: '2.0', id: 'b', method: 'foo' }),
+      ]);
+
+      expect(l1).toHaveBeenCalledWith(expect.objectContaining({ id: 'a', result: 'shared' }));
+      expect(l2).toHaveBeenCalledWith(expect.objectContaining({ id: 'b', result: 'shared' }));
+    });
+  });
+});

--- a/tests/client/fake-transport.ts
+++ b/tests/client/fake-transport.ts
@@ -1,0 +1,117 @@
+import type { Channel, Transport } from '@icp-sdk/signer';
+
+// `JsonRpcRequest` / `JsonRpcResponse` aren't re-exported from the package
+// root; extract the request shape from `Channel['send']` and redeclare the
+// JSON-RPC 2.0 response shape locally.
+type JsonRpcRequest = Parameters<Channel['send']>[0];
+
+interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+type JsonRpcResponse =
+  | { jsonrpc: '2.0'; id: string | number | null; result: unknown }
+  | { jsonrpc: '2.0'; id: string | number | null; error: JsonRpcError };
+
+export interface FakeTransportOptions {
+  url?: string;
+  windowOpenerFeatures?: string;
+  [key: string]: unknown;
+}
+
+export type RequestHandler = (
+  request: JsonRpcRequest,
+) => JsonRpcResponse | undefined | Promise<JsonRpcResponse | undefined>;
+
+/**
+ * In-memory {@link Transport} for tests. Register handlers via
+ * {@link onRequest}; each handler sees every request and may return either a
+ * response (echoing `request.id`) or `undefined` to pass. Handlers are tried
+ * in registration order and the first response wins — so tests can compose
+ * independent per-method helpers without overwriting each other.
+ */
+export class FakeTransport implements Transport {
+  static instances: FakeTransport[] = [];
+
+  static last(): FakeTransport {
+    const t = FakeTransport.instances.at(-1);
+    if (!t) throw new Error('No FakeTransport instance exists');
+    return t;
+  }
+
+  static reset(): void {
+    FakeTransport.instances = [];
+  }
+
+  readonly options: FakeTransportOptions;
+  readonly requests: JsonRpcRequest[] = [];
+  readonly #handlers: RequestHandler[] = [];
+
+  constructor(options: FakeTransportOptions = {}) {
+    this.options = options;
+    FakeTransport.instances.push(this);
+  }
+
+  onRequest(handler: RequestHandler): void {
+    this.#handlers.push(handler);
+  }
+
+  async establishChannel(): Promise<Channel> {
+    return new FakeChannel(this.#handlers, this.requests);
+  }
+}
+
+class FakeChannel implements Channel {
+  closed = false;
+  readonly #handlers: RequestHandler[];
+  readonly #requests: JsonRpcRequest[];
+  readonly #responseListeners = new Set<(response: JsonRpcResponse) => void>();
+  readonly #closeListeners = new Set<() => void>();
+
+  constructor(handlers: RequestHandler[], requests: JsonRpcRequest[]) {
+    this.#handlers = handlers;
+    this.#requests = requests;
+  }
+
+  addEventListener(event: 'close', listener: () => void): () => void;
+  addEventListener(event: 'response', listener: (response: JsonRpcResponse) => void): () => void;
+  addEventListener(
+    event: 'close' | 'response',
+    listener: ((response: JsonRpcResponse) => void) | (() => void),
+  ): () => void {
+    if (event === 'response') {
+      const fn = listener as (response: JsonRpcResponse) => void;
+      this.#responseListeners.add(fn);
+      return () => this.#responseListeners.delete(fn);
+    }
+    const fn = listener as () => void;
+    this.#closeListeners.add(fn);
+    return () => this.#closeListeners.delete(fn);
+  }
+
+  async send(request: JsonRpcRequest): Promise<void> {
+    if (this.closed) {
+      throw new Error('FakeTransport: cannot send on a closed channel');
+    }
+    this.#requests.push(request);
+    // Per JSON-RPC 2.0, a request without an id is a Notification and receives
+    // no response. Mirroring that means tests whose code forgets to set an id
+    // will hang on the signer's correlation wait and fail via test timeout —
+    // the same way they would against a real signer.
+    if (request.id === undefined || request.id === null) return;
+    for (const handler of this.#handlers) {
+      const response = await handler(request);
+      if (response === undefined) continue;
+      for (const listener of this.#responseListeners) listener(response);
+      return;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    for (const listener of this.#closeListeners) listener();
+  }
+}

--- a/tests/client/fake-transport.ts
+++ b/tests/client/fake-transport.ts
@@ -97,9 +97,10 @@ class FakeChannel implements Channel {
     }
     this.#requests.push(request);
     // Per JSON-RPC 2.0, a request without an id is a Notification and receives
-    // no response. Mirroring that means tests whose code forgets to set an id
-    // will hang on the signer's correlation wait and fail via test timeout —
-    // the same way they would against a real signer.
+    // no response. This test transport treats `id: null` the same way, so
+    // tests whose code omits an id (or sets it to `null`) hang on the signer's
+    // correlation wait and fail via test timeout — the same as against a real
+    // signer.
     if (request.id === undefined || request.id === null) return;
     for (const handler of this.#handlers) {
       const response = await handler(request);


### PR DESCRIPTION
The `requestAttributes` call was sending a JSON-RPC request without an `id`, so the signer couldn't correlate a response and the promise never resolved.

The test harness was fully mocking `@icp-sdk/signer` with `vi.fn()` stubs that resolved regardless of the outgoing request shape — that's how the missing `id` slipped through. Replaced the mocks with the real `Signer` driven by an in-memory `FakeTransport` implementing the real `Transport` interface. Requests without an `id` are treated as JSON-RPC 2.0 notifications (no dispatch, signer hangs, test times out), so this class of bug now surfaces as a test failure.

Added coverage for parallel and sequential `signIn` + `requestAttributes` flows, `signIn` options forwarding (`targets`, `maxTimeToLive`, `derivationOrigin`, `windowOpenerFeatures`), and stand-alone unit tests for `FakeTransport`.