### PR TITLE
build: bump `@icp-sdk/signer` to v5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.3.0",
+    "@icp-sdk/signer": "^5.3.1",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@icp-sdk/signer':
-        specifier: ^5.3.0
-        version: 5.3.0(@icp-sdk/core@5.2.1)
+        specifier: ^5.3.1
+        version: 5.3.1(@icp-sdk/core@5.2.1)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -337,8 +337,8 @@ packages:
   '@icp-sdk/core@5.2.1':
     resolution: {integrity: sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==}
 
-  '@icp-sdk/signer@5.3.0':
-    resolution: {integrity: sha512-ZBRzoMudjLqMGAUp7RUKa5rl13OR+XmHFfvGi4Qib1LoT8XFH7r+HdNYg+MgbWoRXwnO+a4e5OP3cwJ/jQhdMQ==}
+  '@icp-sdk/signer@5.3.1':
+    resolution: {integrity: sha512-2IJOdAnAit6SLZU3FTfPK0he4kCR+mr3IunDk62PgZCQKzvJ2DyV8FPBIceDpMSOXJLuXEMwd9E4Hdc53n0nrw==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -1170,7 +1170,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       asn1js: 3.0.7
 
-  '@icp-sdk/signer@5.3.0(@icp-sdk/core@5.2.1)':
+  '@icp-sdk/signer@5.3.1(@icp-sdk/core@5.2.1)':
     dependencies:
       '@icp-sdk/core': 5.2.1
 


### PR DESCRIPTION
Bumps `@icp-sdk/signer` from `^5.3.0` to `^5.3.1`.

## Test plan
- [ ] CI passes