### PR TITLE
refactor!: rename AuthClient.logout to signOut

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ try {
 console.log('Identity:', identity.getPrincipal().toString());
 
 // later, to end the session
-await authClient.logout();
+await authClient.signOut();
 ```
 
 ### One-Click OpenID Sign-In

--- a/docs/src/content/docs/quick-start.md
+++ b/docs/src/content/docs/quick-start.md
@@ -55,7 +55,7 @@ await agent.call(appCanisterId, {
 });
 
 // later in your app
-await authClient.logout();
+await authClient.signOut();
 ```
 
 ## Next Steps

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -110,7 +110,7 @@ export interface IdleOptions extends IdleManagerOptions {
   disableIdle?: boolean;
 
   /**
-   * Disables the default idle callback (logout & reload).
+   * Disables the default idle callback (sign-out & reload).
    * @default false
    */
   disableDefaultIdleCallback?: boolean;
@@ -300,10 +300,10 @@ export class AuthClient {
   /**
    * Clears the stored session and resets the client to an anonymous state.
    *
-   * @param options - Logout options.
-   * @param options.returnTo - URL to navigate to after logout.
+   * @param options - Sign-out options.
+   * @param options.returnTo - URL to navigate to after sign-out.
    */
-  async logout(options: { returnTo?: string } = {}): Promise<void> {
+  async signOut(options: { returnTo?: string } = {}): Promise<void> {
     await deleteStorage(this.#storage);
 
     this.#identity = new AnonymousIdentity();
@@ -355,7 +355,7 @@ export class AuthClient {
     const idleOptions = this.#options?.idleOptions;
     if (!idleOptions?.onIdle && !idleOptions?.disableDefaultIdleCallback) {
       this.idleManager?.registerCallback(() => {
-        this.logout();
+        this.signOut();
         location.reload();
       });
     }

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -135,15 +135,15 @@ describe('AuthClient', () => {
     expect(resolved.getPrincipal().isAnonymous()).toBe(false);
   });
 
-  it('should log users out', async () => {
+  it('should sign users out', async () => {
     const client = new AuthClient();
-    await client.logout();
+    await client.signOut();
     expect(client.isAuthenticated()).toBe(false);
     const identity = await client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
   });
 
-  it('should not initialize an idleManager if the user is not logged in', async () => {
+  it('should not initialize an idleManager if the user is not signed in', async () => {
     const client = new AuthClient();
     await client.getIdentity(); // wait for hydration
     expect(client.idleManager).toBeUndefined();
@@ -275,18 +275,18 @@ describe('AuthClient signIn', () => {
     expect(client.isAuthenticated()).toBe(true);
   });
 
-  it('should clear the localStorage expiration flag on logout', async () => {
+  it('should clear the localStorage expiration flag on sign-out', async () => {
     const client = new AuthClient({ idleOptions: { disableIdle: true } });
     handleSignIn(FakeTransport.last());
     await client.signIn();
     expect(client.isAuthenticated()).toBe(true);
-    await client.logout();
+    await client.signOut();
     expect(client.isAuthenticated()).toBe(false);
   });
 });
 
 describe('AuthClient idle behavior', () => {
-  it('should log out after idle and reload the window by default', async () => {
+  it('should sign out after idle and reload the window by default', async () => {
     const storage: AuthClientStorage = {
       remove: vi.fn(),
       get: vi.fn().mockResolvedValue(null),


### PR DESCRIPTION
Pairs with the existing `signIn()` method for naming consistency. The behavior is unchanged: `signOut` clears the stored session and resets the client to an anonymous state, with the same optional `returnTo` parameter.

Tests, codestyle, and build all pass locally.

<!--
BREAKING CHANGE: `AuthClient.logout()` is renamed to `AuthClient.signOut()`. Callers must rename `authClient.logout(...)` to `authClient.signOut(...)`.
-->

BREAKING CHANGE: `AuthClient.logout()` is renamed to `AuthClient.signOut()`. Callers must rename `authClient.logout(...)` to `authClient.signOut(...)`.