### PR TITLE
feat(auth-client): support Promise<Uint8Array> nonce in requestAttributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.3.1",
+    "@icp-sdk/signer": "^5.4.0",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@icp-sdk/signer':
-        specifier: ^5.3.1
-        version: 5.3.1(@icp-sdk/core@5.2.1)
+        specifier: ^5.4.0
+        version: 5.4.0(@icp-sdk/core@5.2.1)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -337,8 +337,8 @@ packages:
   '@icp-sdk/core@5.2.1':
     resolution: {integrity: sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==}
 
-  '@icp-sdk/signer@5.3.1':
-    resolution: {integrity: sha512-2IJOdAnAit6SLZU3FTfPK0he4kCR+mr3IunDk62PgZCQKzvJ2DyV8FPBIceDpMSOXJLuXEMwd9E4Hdc53n0nrw==}
+  '@icp-sdk/signer@5.4.0':
+    resolution: {integrity: sha512-l7HKJ02ZszAWvBV0dSW7uNVNVwsVAlWp9zMirHk/wrtQpglMDSxh1kcXiha5R5YkIooy/d5Pt8QKHDPG4Orj6A==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -1170,7 +1170,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       asn1js: 3.0.7
 
-  '@icp-sdk/signer@5.3.1(@icp-sdk/core@5.2.1)':
+  '@icp-sdk/signer@5.4.0(@icp-sdk/core@5.2.1)':
     dependencies:
       '@icp-sdk/core': 5.2.1
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -332,25 +332,17 @@ export class AuthClient {
   // scheduled by a prior request on the same signer). The original auto-close
   // setting is restored before sendRequest, so the next response resumes
   // normal close behaviour.
-  //
-  // The `autoCloseTransportChannel` runtime accessor on Signer is being added
-  // in @icp-sdk/signer >= 5.4.0. Until the dependency is bumped, suppress the
-  // type errors and rely on the assignment being a harmless no-op against
-  // older versions.
   async #resolveNonce(nonce: Uint8Array | Promise<Uint8Array>): Promise<Uint8Array> {
     if (!(nonce instanceof Promise)) {
       return nonce;
     }
 
     await this.#signer.openChannel();
-    // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
-    const previousAutoClose: boolean = this.#signer.autoCloseTransportChannel;
-    // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
+    const previousAutoClose = this.#signer.autoCloseTransportChannel;
     this.#signer.autoCloseTransportChannel = false;
     try {
       return await nonce;
     } finally {
-      // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
       this.#signer.autoCloseTransportChannel = previousAutoClose;
     }
   }

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -259,17 +259,25 @@ export class AuthClient {
   /**
    * Requests signed identity attributes from the identity provider.
    *
+   * The `nonce` may be a `Uint8Array` or a `Promise<Uint8Array>`. Passing a
+   * promise lets the identity provider window open while the nonce (typically
+   * fetched from the RP canister) is still being resolved, avoiding a perceived
+   * delay before the user sees the prompt. Auto-close of the signer transport
+   * channel is temporarily disabled while awaiting the promise so the window
+   * cannot be closed out from under the pending flow.
+   *
    * @param params - Request parameters.
    * @param params.keys - Attribute keys to request (e.g. `['email', 'name']`).
-   * @param params.nonce - 32-byte nonce issued by the RP canister.
+   * @param params.nonce - 32-byte nonce issued by the RP canister, or a promise
+   *   resolving to one.
    * @returns Signed attribute data and signature.
    * @throws When the identity provider returns an error or an invalid response.
    */
   async requestAttributes(params: {
     keys: string[];
-    nonce: Uint8Array;
+    nonce: Uint8Array | Promise<Uint8Array>;
   }): Promise<SignedAttributes> {
-    const nonceBytes = params.nonce;
+    const nonceBytes = await this.#resolveNonce(params.nonce);
 
     const response = await this.#signer.sendRequest({
       jsonrpc: '2.0',
@@ -315,6 +323,35 @@ export class AuthClient {
       } catch {
         window.location.href = options.returnTo;
       }
+    }
+  }
+
+  // When the caller passes a Promise<Uint8Array>, open the transport channel
+  // first so the identity provider window is visible while we wait, and
+  // suspend auto-close so it can't fire mid-await (e.g. due to a close
+  // scheduled by a prior request on the same signer). The original auto-close
+  // setting is restored before sendRequest, so the next response resumes
+  // normal close behaviour.
+  //
+  // The `autoCloseTransportChannel` runtime accessor on Signer is being added
+  // in @icp-sdk/signer >= 5.4.0. Until the dependency is bumped, suppress the
+  // type errors and rely on the assignment being a harmless no-op against
+  // older versions.
+  async #resolveNonce(nonce: Uint8Array | Promise<Uint8Array>): Promise<Uint8Array> {
+    if (!(nonce instanceof Promise)) {
+      return nonce;
+    }
+
+    await this.#signer.openChannel();
+    // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
+    const previousAutoClose: boolean = this.#signer.autoCloseTransportChannel;
+    // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
+    this.#signer.autoCloseTransportChannel = false;
+    try {
+      return await nonce;
+    } finally {
+      // @ts-expect-error -- see note above; remove after @icp-sdk/signer bump
+      this.#signer.autoCloseTransportChannel = previousAutoClose;
     }
   }
 

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -516,6 +516,57 @@ describe('AuthClient requestAttributes', () => {
       'Invalid response: missing data or signature',
     );
   });
+
+  it('should accept a Promise<Uint8Array> nonce and forward the resolved value', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleRequestAttributes(transport);
+
+    const nonceBytes = new Uint8Array(32).fill(7);
+    const result = await client.requestAttributes({
+      keys: ['email'],
+      nonce: Promise.resolve(nonceBytes),
+    });
+
+    expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonceBytes)));
+    expect(Array.from(result.data)).toEqual(Array.from(new TextEncoder().encode('hello')));
+  });
+
+  it('should open the transport channel before awaiting a nonce promise', async () => {
+    const client = new AuthClient();
+    const transport = FakeTransport.last();
+    handleRequestAttributes(transport);
+
+    const establishOrder: string[] = [];
+    const originalEstablish = transport.establishChannel.bind(transport);
+    transport.establishChannel = async () => {
+      establishOrder.push('establish');
+      return originalEstablish();
+    };
+
+    const nonceBytes = new Uint8Array(32).fill(9);
+    const noncePromise = new Promise<Uint8Array>((resolve) => {
+      // Resolving in a later microtask so the channel has time to open first.
+      queueMicrotask(() => {
+        establishOrder.push('resolve-nonce');
+        resolve(nonceBytes);
+      });
+    });
+
+    await client.requestAttributes({ keys: ['email'], nonce: noncePromise });
+
+    expect(establishOrder).toEqual(['establish', 'resolve-nonce']);
+    expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonceBytes)));
+  });
+
+  it('should propagate rejection from a nonce promise', async () => {
+    const client = new AuthClient();
+    handleRequestAttributes(FakeTransport.last());
+
+    await expect(
+      client.requestAttributes({ keys: ['email'], nonce: Promise.reject(new Error('boom')) }),
+    ).rejects.toThrow('boom');
+  });
 });
 
 describe('AuthClient signIn + requestAttributes', () => {


### PR DESCRIPTION
## Summary

`AuthClient.requestAttributes` now accepts `nonce: Uint8Array | Promise<Uint8Array>`. When a promise is passed, the client opens the signer channel first (so the II window appears immediately), holds the auto-close open while awaiting the nonce, then sends the attributes request.

## Motivation

Callers that need to fetch a nonce asynchronously (e.g. from a backend endpoint that signs the request) currently have to await the nonce *before* calling `requestAttributes`. That delays the II window from opening until the backend responds, which (a) feels laggy and (b) can be blocked by popup heuristics that require the window to open synchronously in the user gesture.

Accepting `Promise<Uint8Array>` lets the window open first and the backend round-trip happen in parallel.

## Behavior

- If `nonce` is a `Uint8Array`, behavior is unchanged.
- If `nonce` is a `Promise<Uint8Array>`, the client:
  1. Opens the signer transport channel.
  2. Disables the signer's auto-close (via the runtime accessor added in @icp-sdk/signer 5.4.0).
  3. Awaits the promise.
  4. Restores the previous auto-close state.
  5. Sends the attributes request.

Auto-close behaviour after restore: the signer's auto-close timer is scheduled at response-receipt time using the current value of `autoCloseTransportChannel`. Because the flag is restored before `sendRequest` is called, the next response (the attributes response) sees the flag as `true` and schedules the close as normal.

## Test plan

- [x] New tests cover: promise nonce forwards the resolved value, channel opens before the nonce is awaited (ordering), and promise rejection propagates.
- [x] Uint8Array path unchanged — existing tests still pass (73/73).
- [x] @icp-sdk/signer bumped to ^5.4.0; type-level integration with the runtime `autoCloseTransportChannel` accessor verified by tsc.