### PR TITLE
feat(auth-client)!: URL redirect transport

### DIFF
--- a/docs/src/content/docs/upgrading/v8.md
+++ b/docs/src/content/docs/upgrading/v8.md
@@ -1,0 +1,69 @@
+---
+title: Upgrading to v8
+description: Breaking changes in @icp-sdk/auth v8
+sidebar:
+  label: v8
+  order: 2
+---
+
+v8 changes the `requestAttributes` `nonce` parameter from a value to a callback, and adds an opt-in top-level redirect sign-in flow.
+
+## `requestAttributes` nonce is now a callback (breaking)
+
+`AuthClient.requestAttributes` previously took the nonce as a `Uint8Array` or a `Promise<Uint8Array>`. It now takes a **callback that fetches the nonce**, returning a `Promise<Uint8Array>`. Pass the fetching function itself — don't `await` it at the call site:
+
+```diff
+- await authClient.requestAttributes({
+-   keys: ['email'],
+-   nonce: await fetchNonce(),
+- });
++ await authClient.requestAttributes({
++   keys: ['email'],
++   nonce: () => fetchNonce(),
++ });
+```
+
+The client invokes the callback when it needs the nonce and, in redirect mode, journals the produced value and reuses it when the flow replays after the redirect — so the signer signs against the same single-use nonce rather than a freshly fetched one. Pre-fetching the nonce and wrapping the result (`nonce: () => Promise.resolve(alreadyFetched)`) re-runs the fetch on every page load and defeats that, so pass the fetch function instead.
+
+The nonce is a callback rather than a value so the redirect flow (below) can journal it and reuse the exact same bytes when the flow replays after the redirect, instead of fetching a fresh single-use nonce the signer never signed against. In the default window flow the behaviour is otherwise unchanged: the callback still lets the identity provider window open while the nonce resolves.
+
+## New: top-level redirect sign-in via `transport: 'redirect'`
+
+`AuthClient` gains an optional `transport` option. It defaults to `'window'` — the existing flow, where the identity provider opens in a separate browser tab or window (a popup when `windowOpenerFeatures` is set) and communicates over ICRC-29 `postMessage`. Set it to `'redirect'` to talk to the identity provider over the [ICRC-167](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_167_browser_url_transport.md) URL transport — a full-page redirect — which suits full-page sign-in flows that shouldn't need a user gesture to open a separate window — for example redirecting straight to sign-in when someone lands on a restricted page (opening a tab or window requires a user interaction, a redirect does not) — as well as native apps that hand off to the browser via universal links (deep links).
+
+```ts
+const authClient = new AuthClient({ transport: 'redirect' });
+
+// IMPORTANT: with 'redirect' the page unloads on each step, so this code must
+// run directly on page load — not deferred behind a click handler. A fresh
+// visit starts the flow; the identity provider's return replays it to
+// completion on the reload.
+const identity = await authClient.signIn();
+```
+
+Requirements for `'redirect'`:
+
+- **Run `signIn` / `requestAttributes` on page load.** The redirect unloads the page and the flow re-runs when the identity provider returns, so the calls must execute again on that return load — not from an event handler that only fires on user interaction.
+- The callback URL is the current page's URL (`location.origin + location.pathname`), so that page must be on an origin you control and declared in that origin's `/.well-known/ii-auth-callbacks` allow-list. Give each flow its own route so its persisted state stays isolated.
+- The session key and the attributes nonce survive the redirect automatically — the client persists them and reuses them on the return load.
+
+### Carrying your own values across the redirect
+
+Anything you compute on the first visit (from `location`, a fetch, `crypto`, …) is recomputed on the return load, since the page re-runs. To keep such a value stable — for example the URL to return to once sign-in completes — wrap it in `authClient.memoize`, which runs the callback once on the first visit, journals the result, and replays it on the return:
+
+```ts
+const authClient = new AuthClient({ transport: 'redirect' });
+
+// Captured before the redirect, replayed after — even though location.search
+// differs on the return load.
+const next = await authClient.memoize(
+  () => new URLSearchParams(location.search).get('next') ?? '/',
+);
+
+await authClient.signIn();
+location.assign(next);
+```
+
+Call `memoize` in a stable order relative to `signIn` / `requestAttributes`, and keep its result JSON-serializable. In `'window'` mode it simply runs the callback and returns the result, so the same code works with either transport.
+
+Leaving `transport` unset (or `'window'`) keeps the previous behaviour exactly; this option is purely additive.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.4.0",
+    "@icp-sdk/signer": "^5.5.0",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@icp-sdk/signer':
-        specifier: ^5.4.0
-        version: 5.4.0(@icp-sdk/core@5.2.1)
+        specifier: ^5.5.0
+        version: 5.5.0(@icp-sdk/core@5.2.1)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -337,8 +337,8 @@ packages:
   '@icp-sdk/core@5.2.1':
     resolution: {integrity: sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==}
 
-  '@icp-sdk/signer@5.4.0':
-    resolution: {integrity: sha512-l7HKJ02ZszAWvBV0dSW7uNVNVwsVAlWp9zMirHk/wrtQpglMDSxh1kcXiha5R5YkIooy/d5Pt8QKHDPG4Orj6A==}
+  '@icp-sdk/signer@5.5.0':
+    resolution: {integrity: sha512-ZYKGFL3RwYCPRhB8ej+LykFWT9366nYuYAOUeiTxEvPCyz+sft4j6JBCKftnnJM/x6CgZe/YGgfLCtYjDSH+Qw==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -1170,7 +1170,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       asn1js: 3.0.7
 
-  '@icp-sdk/signer@5.4.0(@icp-sdk/core@5.2.1)':
+  '@icp-sdk/signer@5.5.0(@icp-sdk/core@5.2.1)':
     dependencies:
       '@icp-sdk/core': 5.2.1
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -267,7 +267,9 @@ export class AuthClient {
     const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
     const keyType = this.#options.keyType ?? ECDSA_KEY_LABEL;
 
-    const { key, pendingKeySlot } = await this.#acquireSessionKey(keyType);
+    const { key, pendingKeySlot } = this.#urlTransport
+      ? await this.#ensureSessionKeyForRedirectFlow(this.#urlTransport, keyType)
+      : { key: await this.#ensureSessionKeyForWindowFlow(keyType) };
 
     const delegationChain = await this.#signer.requestDelegation({
       publicKey: key.getPublicKey(),
@@ -303,28 +305,32 @@ export class AuthClient {
     return this.#identity;
   }
 
-  // Obtains the session key that the delegation is bound to.
-  //
-  // In redirect mode `signIn` runs twice — once on the load that navigates to
-  // the identity provider, and again on the return load that replays the
-  // delegation minted for the FIRST load's key. Both runs must therefore use
-  // the same key. A per-flow key id is journaled via the transport (stable
-  // across the redirect) and the key is kept in storage under that id, so the
-  // return load restores the same key rather than generating a fresh one that
-  // would not match the replayed delegation. In 'window' mode there is no
-  // return load, so a fresh key per sign-in is used, nothing extra persisted.
-  async #acquireSessionKey(
+  // Window flow: sign-in completes in a single load, so a fresh session key per
+  // sign-in is enough (or the caller-provided identity), with nothing to
+  // persist for a later load.
+  async #ensureSessionKeyForWindowFlow(
+    keyType: BaseKeyType,
+  ): Promise<SignIdentity | PartialIdentity> {
+    return this.#options.identity ?? (await generateKey(keyType));
+  }
+
+  // Redirect flow: `signIn` runs twice — once on the load that navigates to the
+  // identity provider, and again on the return load that replays the delegation
+  // minted for the FIRST load's key. Both runs must therefore use the same key.
+  // A per-flow key id is journaled via the transport (stable across the
+  // redirect) and the key is kept in storage under that id, so the return load
+  // restores the same key rather than generating a fresh one that would not
+  // match the replayed delegation. A caller-provided identity is already stable
+  // across the redirect, so it is used as-is with nothing persisted.
+  async #ensureSessionKeyForRedirectFlow(
+    transport: UrlTransport,
     keyType: BaseKeyType,
   ): Promise<{ key: SignIdentity | PartialIdentity; pendingKeySlot?: string }> {
-    if (this.#options.identity) {
+    if (this.#options.identity !== undefined) {
       return { key: this.#options.identity };
     }
 
-    if (!this.#urlTransport) {
-      return { key: await generateKey(keyType) };
-    }
-
-    const keyId = await this.#urlTransport.memoize(() => globalThis.crypto.randomUUID());
+    const keyId = await transport.memoize(() => globalThis.crypto.randomUUID());
     const pendingKeySlot = `${PENDING_KEY_PREFIX}${keyId}`;
 
     const restored = await restoreKeyAt(this.#storage, pendingKeySlot);

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -10,7 +10,7 @@ import {
 } from '@icp-sdk/core/identity';
 import type { Principal } from '@icp-sdk/core/principal';
 import { Signer } from '@icp-sdk/signer';
-import { PostMessageTransport } from '@icp-sdk/signer/web';
+import { PostMessageTransport, UrlTransport } from '@icp-sdk/signer/web';
 import { IdleManager, type IdleManagerOptions } from './idle-manager.js';
 import {
   type AuthClientStorage,
@@ -36,6 +36,11 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 // localStorage key used to cache the delegation expiration so that
 // isAuthenticated() can answer synchronously without hitting IndexedDB.
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
+
+// Storage key prefix for a redirect flow's session key, held only while the
+// flow is in progress (keyed by a per-flow id) and removed once the delegation
+// is persisted. See AuthClient.#acquireSessionKey.
+const PENDING_KEY_PREFIX = 'ic-auth-pending-key:';
 
 export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
 
@@ -95,6 +100,30 @@ export interface AuthClientCreateOptions {
   windowOpenerFeatures?: string;
 
   /**
+   * How the client communicates with the identity provider.
+   *
+   * - `'window'` (default) — the identity provider opens in a separate browser
+   *   tab or window (a popup when {@link windowOpenerFeatures} is set) and
+   *   communicates over the ICRC-29 `postMessage` transport.
+   * - `'redirect'` — the current page navigates to the identity provider over
+   *   the ICRC-167 URL transport, which returns to this same page. The callback
+   *   URL is the current page's URL (`location.origin + location.pathname`), so
+   *   that page must be on an origin you control and declared in that origin's
+   *   `/.well-known/ii-auth-callbacks` allow-list. Use it for full-page sign-in
+   *   that shouldn't need a user gesture to open a window (e.g. redirecting on a
+   *   restricted route), or native apps handing off via universal links.
+   *
+   * With `'redirect'` the page unloads on each step and the flow re-runs on the
+   * return load, so call `signIn` / `requestAttributes` directly on the page's
+   * load (not deferred behind, say, a click handler): a fresh visit starts the
+   * flow and the identity provider's return replays it to completion. Give each
+   * flow its own route so its persisted state stays isolated.
+   * @default 'window'
+   * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_167_browser_url_transport.md
+   */
+  transport?: 'window' | 'redirect';
+
+  /**
    * OpenID provider for one-click sign-in. When set, the identity provider
    * URL includes an `openid` search param so the user authenticates via
    * the chosen provider (e.g. Google) instead of seeing Internet Identity directly.
@@ -152,6 +181,9 @@ export class AuthClient {
   #chain: DelegationChain | null = null;
   #storage: AuthClientStorage;
   #signer: Signer;
+  // Set only in redirect mode, so the redirect-specific paths (nonce/key
+  // journaling) can reach `memoize`. Undefined in the default 'window' mode.
+  #urlTransport: UrlTransport | undefined;
   #options: AuthClientCreateOptions;
   #initPromise: Promise<void> | null = null;
   idleManager: IdleManager | undefined;
@@ -167,10 +199,20 @@ export class AuthClient {
       identityProviderUrl.searchParams.set('openid', OPENID_PROVIDER_URLS[options.openIdProvider]);
     }
 
-    const transport = new PostMessageTransport({
-      url: identityProviderUrl.toString(),
-      windowOpenerFeatures: options.windowOpenerFeatures,
-    });
+    const transport =
+      options.transport === 'redirect'
+        ? new UrlTransport({
+            url: identityProviderUrl.toString(),
+            // The callback is this page: a fresh visit starts the flow and the
+            // provider's return lands back here to replay it. Drop any query
+            // and fragment so it stays stable across the redirect.
+            callbackUrl: `${globalThis.location.origin}${globalThis.location.pathname}`,
+          })
+        : new PostMessageTransport({
+            url: identityProviderUrl.toString(),
+            windowOpenerFeatures: options.windowOpenerFeatures,
+          });
+    this.#urlTransport = transport instanceof UrlTransport ? transport : undefined;
 
     this.#signer = new Signer({
       transport,
@@ -223,10 +265,9 @@ export class AuthClient {
     await this.#signer.openChannel();
 
     const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
+    const keyType = this.#options.keyType ?? ECDSA_KEY_LABEL;
 
-    // Fresh key per sign-in so each session has its own cryptographic identity.
-    const key =
-      this.#options.identity ?? (await generateKey(this.#options.keyType ?? ECDSA_KEY_LABEL));
+    const { key, pendingKeySlot } = await this.#acquireSessionKey(keyType);
 
     const delegationChain = await this.#signer.requestDelegation({
       publicKey: key.getPublicKey(),
@@ -253,31 +294,81 @@ export class AuthClient {
     await persistChain(this.#storage, this.#chain);
     await persistKey(this.#storage, key);
 
+    // The flow is complete: the delegation is bound to this key and stored, so
+    // the per-flow pending copy is no longer needed.
+    if (pendingKeySlot !== undefined) {
+      await this.#storage.remove(pendingKeySlot);
+    }
+
     return this.#identity;
+  }
+
+  // Obtains the session key that the delegation is bound to.
+  //
+  // In redirect mode `signIn` runs twice — once on the load that navigates to
+  // the identity provider, and again on the return load that replays the
+  // delegation minted for the FIRST load's key. Both runs must therefore use
+  // the same key. A per-flow key id is journaled via the transport (stable
+  // across the redirect) and the key is kept in storage under that id, so the
+  // return load restores the same key rather than generating a fresh one that
+  // would not match the replayed delegation. In 'window' mode there is no
+  // return load, so a fresh key per sign-in is used, nothing extra persisted.
+  async #acquireSessionKey(
+    keyType: BaseKeyType,
+  ): Promise<{ key: SignIdentity | PartialIdentity; pendingKeySlot?: string }> {
+    if (this.#options.identity) {
+      return { key: this.#options.identity };
+    }
+
+    if (!this.#urlTransport) {
+      return { key: await generateKey(keyType) };
+    }
+
+    const keyId = await this.#urlTransport.memoize(() => globalThis.crypto.randomUUID());
+    const pendingKeySlot = `${PENDING_KEY_PREFIX}${keyId}`;
+
+    const restored = await restoreKeyAt(this.#storage, pendingKeySlot);
+    if (restored) {
+      return { key: restored, pendingKeySlot };
+    }
+
+    const key = await generateKey(keyType);
+    await this.#storage.set(pendingKeySlot, serializeKey(key));
+    return { key, pendingKeySlot };
   }
 
   /**
    * Requests signed identity attributes from the identity provider.
    *
-   * The `nonce` may be a `Uint8Array` or a `Promise<Uint8Array>`. Passing a
-   * promise lets the identity provider window open while the nonce (typically
-   * fetched from the RP canister) is still being resolved, avoiding a perceived
-   * delay before the user sees the prompt. Auto-close of the signer transport
-   * channel is temporarily disabled while awaiting the promise so the window
-   * cannot be closed out from under the pending flow.
+   * The `nonce` is a callback that produces the 32-byte nonce (typically
+   * fetched from the RP canister), returning a promise resolving to it. It is a
+   * callback rather than a value so the redirect flow can journal the nonce and
+   * reuse the exact same bytes when the flow replays on the return load,
+   * instead of fetching a fresh single-use nonce that the signer never signed
+   * against.
+   *
+   * In 'window' mode the callback lets the identity provider window open while the
+   * nonce is still resolving, avoiding a perceived delay before the user sees
+   * the prompt; auto-close of the signer transport channel is temporarily
+   * disabled while awaiting so the window cannot be closed out from under the
+   * pending flow.
    *
    * @param params - Request parameters.
    * @param params.keys - Attribute keys to request (e.g. `['email', 'name']`).
-   * @param params.nonce - 32-byte nonce issued by the RP canister, or a promise
-   *   resolving to one.
+   * @param params.nonce - Produces the 32-byte nonce issued by the RP canister,
+   *   as a promise resolving to it.
    * @returns Signed attribute data and signature.
    * @throws When the identity provider returns an error or an invalid response.
    */
   async requestAttributes(params: {
     keys: string[];
-    nonce: Uint8Array | Promise<Uint8Array>;
+    nonce: () => Promise<Uint8Array>;
   }): Promise<SignedAttributes> {
-    const nonceBytes = await this.#resolveNonce(params.nonce);
+    // In redirect mode the nonce is journaled (base64, since the journal is
+    // JSON) so the replay on the return load signs against the same bytes.
+    const nonceBytes = this.#urlTransport
+      ? fromBase64(await this.#urlTransport.memoize(async () => toBase64(await params.nonce())))
+      : await this.#resolveNonce(params.nonce);
 
     const response = await this.#signer.sendRequest({
       jsonrpc: '2.0',
@@ -306,6 +397,44 @@ export class AuthClient {
   }
 
   /**
+   * Runs and journals a piece of your own async work so its result stays stable
+   * across the `'redirect'` flow.
+   *
+   * In `'redirect'` mode the page unloads on each step and `signIn` /
+   * `requestAttributes` re-run on the return load, so a value you compute on the
+   * first visit (from `location`, a fetch, `crypto`, …) would otherwise be
+   * recomputed — and may differ — on the return. Wrap it in `memoize`: it runs
+   * `produce` once on the first visit, journals the result, and replays that
+   * result on the return load instead of re-running. Use it for a value the
+   * post-flow code depends on, e.g. the URL to navigate to once sign-in
+   * completes:
+   *
+   * ```ts
+   * const next = await authClient.memoize(
+   *   () => new URLSearchParams(location.search).get('next') ?? '/',
+   * );
+   * await authClient.signIn();
+   * location.assign(next); // the value captured before the redirect
+   * ```
+   *
+   * Call `memoize` in a stable order relative to `signIn` / `requestAttributes`
+   * across loads (same order every load — branch only on values recovered from
+   * earlier results), and keep the result JSON-serializable, since the journal
+   * is JSON.
+   *
+   * In `'window'` mode there is no redirect, so this simply runs `produce` and
+   * returns its result without persisting anything.
+   * @param produce - Produces the value to journal on the first load.
+   * @returns The produced value, or the journaled value on a replay load.
+   */
+  async memoize<T>(produce: () => T | Promise<T>): Promise<T> {
+    if (this.#urlTransport) {
+      return this.#urlTransport.memoize(produce);
+    }
+    return produce();
+  }
+
+  /**
    * Clears the stored session and resets the client to an anonymous state.
    *
    * @param options - Sign-out options.
@@ -326,22 +455,19 @@ export class AuthClient {
     }
   }
 
-  // When the caller passes a Promise<Uint8Array>, open the transport channel
-  // first so the identity provider window is visible while we wait, and
+  // Popup-mode nonce resolution. Start the fetch, then open the transport
+  // channel so the identity provider window is visible while we wait, and
   // suspend auto-close so it can't fire mid-await (e.g. due to a close
   // scheduled by a prior request on the same signer). The original auto-close
   // setting is restored before sendRequest, so the next response resumes
   // normal close behaviour.
-  async #resolveNonce(nonce: Uint8Array | Promise<Uint8Array>): Promise<Uint8Array> {
-    if (!(nonce instanceof Promise)) {
-      return nonce;
-    }
-
+  async #resolveNonce(nonce: () => Promise<Uint8Array>): Promise<Uint8Array> {
+    const value = nonce();
     await this.#signer.openChannel();
     const previousAutoClose = this.#signer.autoCloseTransportChannel;
     this.#signer.autoCloseTransportChannel = false;
     try {
-      return await nonce;
+      return await value;
     } finally {
       this.#signer.autoCloseTransportChannel = previousAutoClose;
     }
@@ -471,6 +597,31 @@ async function restoreKey(
     // The stored value may be corrupt or from an incompatible version.
     // Returning null lets the caller fall through to key generation,
     // which is safer than crashing on startup.
+    return null;
+  }
+}
+
+/**
+ * Loads a session key from a specific storage slot, deserializing by stored
+ * shape (`CryptoKeyPair` → ECDSA, JSON string → Ed25519). Unlike
+ * {@link restoreKey} it does not migrate from localStorage — it reads only the
+ * given slot, as used for a redirect flow's per-flow pending key.
+ * @param storage - The storage backend.
+ * @param storageKey - The slot to read.
+ */
+async function restoreKeyAt(
+  storage: AuthClientStorage,
+  storageKey: string,
+): Promise<SignIdentity | PartialIdentity | null> {
+  const stored = await storage.get(storageKey);
+  if (!stored) return null;
+
+  try {
+    if (typeof stored === 'object') {
+      return await ECDSAKeyIdentity.fromKeyPair(stored);
+    }
+    return Ed25519KeyIdentity.fromJSON(stored);
+  } catch {
     return null;
   }
 }

--- a/tests/client/auth-client-redirect.test.ts
+++ b/tests/client/auth-client-redirect.test.ts
@@ -1,0 +1,210 @@
+import { DelegationChain, Ed25519KeyIdentity } from '@icp-sdk/core/identity';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthClient } from '../../src/client/auth-client.ts';
+import { IdleManager } from '../../src/client/idle-manager.ts';
+import type { AuthClientStorage, StoredKey } from '../../src/client/storage.ts';
+import { FakeUrlTransport } from './fake-url-transport.ts';
+
+// Redirect mode selects `UrlTransport` from `@icp-sdk/signer/web`; swap it for
+// an in-memory fake so the flow can be driven without a real page navigation.
+// `PostMessageTransport` is left as the real export — these tests never use it.
+vi.mock('@icp-sdk/signer/web', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@icp-sdk/signer/web')>();
+  const { FakeUrlTransport } = await import('./fake-url-transport.ts');
+  return { ...actual, UrlTransport: FakeUrlTransport };
+});
+
+const CALLBACK_ORIGIN = 'https://relying.example.com';
+const CALLBACK_PATH = '/connect';
+const CALLBACK_URL = `${CALLBACK_ORIGIN}${CALLBACK_PATH}`;
+const PENDING_KEY_PREFIX = 'ic-auth-pending-key:';
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+/** A shared in-memory storage so two "loads" see the same persisted state. */
+function createSharedStorage(): AuthClientStorage & { map: Map<string, StoredKey> } {
+  const map = new Map<string, StoredKey>();
+  return {
+    map,
+    get: async (key) => map.get(key) ?? null,
+    set: async (key, value) => void map.set(key, value),
+    remove: async (key) => void map.delete(key),
+  };
+}
+
+async function delegationBody() {
+  const key = Ed25519KeyIdentity.generate();
+  const chain = await DelegationChain.create(key, key.getPublicKey(), new Date(Date.now() + 3.6e6));
+  return {
+    result: {
+      publicKey: toBase64(new Uint8Array(chain.publicKey)),
+      signerDelegation: chain.delegations.map((sd) => ({
+        delegation: {
+          pubkey: toBase64(new Uint8Array(sd.delegation.pubkey)),
+          expiration: sd.delegation.expiration.toString(),
+          targets: sd.delegation.targets?.map((t) => t.toText()),
+        },
+        signature: toBase64(new Uint8Array(sd.signature)),
+      })),
+    },
+  };
+}
+
+const SIGN_IN_BODY = await delegationBody();
+
+function handleSignIn(transport: FakeUrlTransport): void {
+  transport.onRequest((req) => {
+    if (req.method !== 'icrc34_delegation' || req.id == null) return;
+    return { jsonrpc: '2.0', id: req.id, ...SIGN_IN_BODY };
+  });
+}
+
+function handleAttributes(transport: FakeUrlTransport): void {
+  transport.onRequest((req) => {
+    if (req.method !== 'ii-icrc3-attributes' || req.id == null) return;
+    return { jsonrpc: '2.0', id: req.id, result: { data: btoa('hi'), signature: btoa('sig') } };
+  });
+}
+
+const flush = async () => {
+  for (let i = 0; i < 15; i++) await new Promise((r) => setTimeout(r, 0));
+};
+
+const pendingSlots = (storage: ReturnType<typeof createSharedStorage>) =>
+  [...storage.map.keys()].filter((k) => k.startsWith(PENDING_KEY_PREFIX));
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  localStorage.clear();
+  FakeUrlTransport.reset();
+  // Redirect mode derives its callback URL from the current location, so give
+  // location a concrete origin + pathname (plus reload for idle teardown).
+  vi.stubGlobal('location', {
+    origin: CALLBACK_ORIGIN,
+    pathname: CALLBACK_PATH,
+    reload: vi.fn(),
+  });
+});
+
+afterEach(async () => {
+  try {
+    IdleManager.create().exit();
+  } catch {
+    // no-op if already torn down
+  }
+  await new Promise((r) => setTimeout(r, 0));
+  localStorage.clear();
+});
+
+describe('AuthClient redirect (UrlTransport) sign-in', () => {
+  it('routes sign-in through the URL transport and cleans up the pending key', async () => {
+    const storage = createSharedStorage();
+    const client = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+
+    const identity = await client.signIn();
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+    expect(FakeUrlTransport.last().requests[0]?.method).toBe('icrc34_delegation');
+    // The key id was journaled via `memoize`, and the pending key was removed
+    // once the delegation was persisted.
+    expect(FakeUrlTransport.journal).toHaveLength(1);
+    expect(pendingSlots(storage)).toEqual([]);
+  });
+
+  it('derives the callback URL from the current location', () => {
+    new AuthClient({ transport: 'redirect' });
+    // origin + pathname of the current page, with any query/fragment dropped.
+    expect(FakeUrlTransport.last().options.callbackUrl).toBe(CALLBACK_URL);
+  });
+
+  it('reuses the session key across the redirect', async () => {
+    const storage = createSharedStorage();
+
+    // Load 1: navigates to the signer and never returns in-context.
+    FakeUrlTransport.nextRespond = false;
+    const client1 = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    const pending1 = client1.signIn().catch(() => undefined); // stays pending
+    await flush();
+
+    const load1 = FakeUrlTransport.last();
+    expect(load1.requests[0]?.method).toBe('icrc34_delegation');
+    expect(pendingSlots(storage)).toHaveLength(1); // key persisted for the return
+    const publicKey1 = load1.requests[0]?.params?.publicKey;
+
+    // Load 2: the signer returns; the flow replays and completes.
+    FakeUrlTransport.nextRespond = true;
+    const client2 = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    const identity = await client2.signIn();
+
+    const load2 = FakeUrlTransport.last();
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+    // The delegation on the return load was requested for the SAME key that
+    // load 1 generated — not a fresh one that would not match.
+    expect(load2.requests[0]?.params?.publicKey).toBe(publicKey1);
+    expect(pendingSlots(storage)).toEqual([]); // cleaned up on completion
+    void pending1;
+  });
+
+  it('memoize journals a caller value and replays it across the redirect', async () => {
+    const produce = vi.fn(() => 'https://relying.example.com/next');
+
+    // Load 1: the value is produced and journaled.
+    const client1 = new AuthClient({ transport: 'redirect', storage: createSharedStorage() });
+    const v1 = await client1.memoize(produce);
+
+    // Load 2 (shared journal): the value replays without re-running produce.
+    const client2 = new AuthClient({ transport: 'redirect', storage: createSharedStorage() });
+    const v2 = await client2.memoize(produce);
+
+    expect(v1).toBe('https://relying.example.com/next');
+    expect(v2).toBe(v1);
+    expect(produce).toHaveBeenCalledOnce(); // not re-run on the return load
+  });
+});
+
+describe('AuthClient redirect (UrlTransport) requestAttributes', () => {
+  it('memoizes the nonce and forwards it as base64', async () => {
+    const client = new AuthClient({ transport: 'redirect', storage: createSharedStorage() });
+    handleAttributes(FakeUrlTransport.last());
+
+    const nonce = new Uint8Array(32).fill(3);
+    const thunk = vi.fn(() => Promise.resolve(nonce));
+    await client.requestAttributes({ keys: ['email'], nonce: thunk });
+
+    expect(thunk).toHaveBeenCalledOnce();
+    expect(FakeUrlTransport.last().requests[0]?.params?.nonce).toBe(toBase64(nonce));
+    expect(FakeUrlTransport.journal).toEqual([toBase64(nonce)]); // journaled as base64
+  });
+
+  it('reuses the memoized nonce across the redirect instead of re-fetching', async () => {
+    const storage = createSharedStorage();
+    let counter = 0;
+    const thunk = vi.fn(() => Promise.resolve(new Uint8Array(32).fill(++counter))); // fresh each call
+
+    // Load 1: fetches the nonce, sends the request, then navigates away.
+    FakeUrlTransport.nextRespond = false;
+    const client1 = new AuthClient({ transport: 'redirect', storage });
+    handleAttributes(FakeUrlTransport.last());
+    const pending1 = client1.requestAttributes({ keys: ['email'], nonce: thunk }).catch(() => null);
+    await flush();
+    const nonce1 = FakeUrlTransport.last().requests[0]?.params?.nonce;
+
+    // Load 2: the flow replays; the nonce must be the one signed against.
+    FakeUrlTransport.nextRespond = true;
+    const client2 = new AuthClient({ transport: 'redirect', storage });
+    handleAttributes(FakeUrlTransport.last());
+    await client2.requestAttributes({ keys: ['email'], nonce: thunk });
+
+    expect(thunk).toHaveBeenCalledOnce(); // not re-fetched on the return load
+    expect(FakeUrlTransport.last().requests[0]?.params?.nonce).toBe(nonce1);
+    void pending1;
+  });
+});

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -14,10 +14,13 @@ import { FakeTransport } from './fake-transport.ts';
 
 // Swap `PostMessageTransport` for `FakeTransport` so `AuthClient` uses the real
 // `Signer` over an in-memory transport — no window is opened and nothing about
-// the signer's JSON-RPC correlation is faked.
-vi.mock('@icp-sdk/signer/web', async () => {
+// the signer's JSON-RPC correlation is faked. `UrlTransport` is kept as the
+// real export so the constructor's `instanceof UrlTransport` transport-select
+// check behaves; redirect-flow tests replace it separately.
+vi.mock('@icp-sdk/signer/web', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@icp-sdk/signer/web')>();
   const { FakeTransport } = await import('./fake-transport.ts');
-  return { PostMessageTransport: FakeTransport };
+  return { ...actual, PostMessageTransport: FakeTransport };
 });
 
 function toBase64(bytes: Uint8Array): string {
@@ -178,6 +181,14 @@ describe('AuthClient', () => {
       },
     });
     expect(client.idleManager).toBeUndefined();
+  });
+
+  it('memoize runs the producer and returns its value in window mode', async () => {
+    const client = new AuthClient(); // default 'window' transport
+    const produce = vi.fn(async () => 'value');
+
+    expect(await client.memoize(produce)).toBe('value');
+    expect(produce).toHaveBeenCalledOnce();
   });
 });
 
@@ -463,7 +474,10 @@ describe('AuthClient requestAttributes', () => {
     handleRequestAttributes(transport);
 
     const nonce = new Uint8Array(32).fill(1);
-    const result = await client.requestAttributes({ keys: ['email', 'name'], nonce });
+    const result = await client.requestAttributes({
+      keys: ['email', 'name'],
+      nonce: () => Promise.resolve(nonce),
+    });
 
     const sent = transport.requests[0];
     expect(sent.method).toBe('ii-icrc3-attributes');
@@ -479,7 +493,7 @@ describe('AuthClient requestAttributes', () => {
     handleRequestAttributes(transport);
 
     const nonce = new Uint8Array(32).fill(42);
-    await client.requestAttributes({ keys: ['email'], nonce });
+    await client.requestAttributes({ keys: ['email'], nonce: () => Promise.resolve(nonce) });
 
     expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonce)));
   });
@@ -489,8 +503,14 @@ describe('AuthClient requestAttributes', () => {
     const transport = FakeTransport.last();
     handleRequestAttributes(transport);
 
-    await client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(1) });
-    await client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(2) });
+    await client.requestAttributes({
+      keys: ['email'],
+      nonce: () => Promise.resolve(new Uint8Array(32).fill(1)),
+    });
+    await client.requestAttributes({
+      keys: ['email'],
+      nonce: () => Promise.resolve(new Uint8Array(32).fill(2)),
+    });
 
     expect(transport.requests[0].params?.nonce).not.toBe(transport.requests[1].params?.nonce);
   });
@@ -502,9 +522,9 @@ describe('AuthClient requestAttributes', () => {
     });
 
     const nonce = new Uint8Array(32).fill(1);
-    await expect(client.requestAttributes({ keys: ['email'], nonce })).rejects.toThrow(
-      'not supported',
-    );
+    await expect(
+      client.requestAttributes({ keys: ['email'], nonce: () => Promise.resolve(nonce) }),
+    ).rejects.toThrow('not supported');
   });
 
   it('should throw when the response is missing data or signature', async () => {
@@ -512,12 +532,12 @@ describe('AuthClient requestAttributes', () => {
     handleRequestAttributes(FakeTransport.last(), { result: { data: btoa('hello') } });
 
     const nonce = new Uint8Array(32).fill(1);
-    await expect(client.requestAttributes({ keys: ['email'], nonce })).rejects.toThrow(
-      'Invalid response: missing data or signature',
-    );
+    await expect(
+      client.requestAttributes({ keys: ['email'], nonce: () => Promise.resolve(nonce) }),
+    ).rejects.toThrow('Invalid response: missing data or signature');
   });
 
-  it('should accept a Promise<Uint8Array> nonce and forward the resolved value', async () => {
+  it('should accept a nonce callback returning a promise and forward the resolved value', async () => {
     const client = new AuthClient();
     const transport = FakeTransport.last();
     handleRequestAttributes(transport);
@@ -525,7 +545,7 @@ describe('AuthClient requestAttributes', () => {
     const nonceBytes = new Uint8Array(32).fill(7);
     const result = await client.requestAttributes({
       keys: ['email'],
-      nonce: Promise.resolve(nonceBytes),
+      nonce: () => Promise.resolve(nonceBytes),
     });
 
     expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonceBytes)));
@@ -553,7 +573,7 @@ describe('AuthClient requestAttributes', () => {
       });
     });
 
-    await client.requestAttributes({ keys: ['email'], nonce: noncePromise });
+    await client.requestAttributes({ keys: ['email'], nonce: () => noncePromise });
 
     expect(establishOrder).toEqual(['establish', 'resolve-nonce']);
     expect(transport.requests[0].params?.nonce).toBe(btoa(String.fromCharCode(...nonceBytes)));
@@ -564,7 +584,7 @@ describe('AuthClient requestAttributes', () => {
     handleRequestAttributes(FakeTransport.last());
 
     await expect(
-      client.requestAttributes({ keys: ['email'], nonce: Promise.reject(new Error('boom')) }),
+      client.requestAttributes({ keys: ['email'], nonce: () => Promise.reject(new Error('boom')) }),
     ).rejects.toThrow('boom');
   });
 });
@@ -578,7 +598,10 @@ describe('AuthClient signIn + requestAttributes', () => {
 
     const [identity, attributes] = await Promise.all([
       client.signIn(),
-      client.requestAttributes({ keys: ['email'], nonce: new Uint8Array(32).fill(1) }),
+      client.requestAttributes({
+        keys: ['email'],
+        nonce: () => Promise.resolve(new Uint8Array(32).fill(1)),
+      }),
     ]);
 
     expect(identity.getPrincipal().isAnonymous()).toBe(false);
@@ -594,7 +617,7 @@ describe('AuthClient signIn + requestAttributes', () => {
     const identity = await client.signIn();
     const attributes = await client.requestAttributes({
       keys: ['email'],
-      nonce: new Uint8Array(32).fill(1),
+      nonce: () => Promise.resolve(new Uint8Array(32).fill(1)),
     });
 
     expect(identity.getPrincipal().isAnonymous()).toBe(false);
@@ -609,7 +632,7 @@ describe('AuthClient signIn + requestAttributes', () => {
 
     const attributes = await client.requestAttributes({
       keys: ['email'],
-      nonce: new Uint8Array(32).fill(1),
+      nonce: () => Promise.resolve(new Uint8Array(32).fill(1)),
     });
     const identity = await client.signIn();
 

--- a/tests/client/fake-url-transport.ts
+++ b/tests/client/fake-url-transport.ts
@@ -1,0 +1,143 @@
+import type { Channel, Transport } from '@icp-sdk/signer';
+
+// `JsonRpcRequest` / `JsonRpcResponse` aren't re-exported from the package
+// root; extract the request shape from `Channel['send']` and redeclare the
+// JSON-RPC 2.0 response shape locally.
+type JsonRpcRequest = Parameters<Channel['send']>[0];
+
+interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+type JsonRpcResponse =
+  | { jsonrpc: '2.0'; id: string | number | null; result: unknown }
+  | { jsonrpc: '2.0'; id: string | number | null; error: JsonRpcError };
+
+export type RequestHandler = (
+  request: JsonRpcRequest,
+) => JsonRpcResponse | undefined | Promise<JsonRpcResponse | undefined>;
+
+/**
+ * In-memory stand-in for `UrlTransport` that lets tests exercise
+ * `AuthClient`'s redirect paths without a real page navigation.
+ *
+ * The real transport persists a call-order journal so a flow replays across
+ * the top-level redirect. This fake models the two moving parts `AuthClient`
+ * depends on:
+ *
+ * - `memoize` records each produced value by call order in a **static** journal
+ *   shared across instances, so a value captured on one "load" (transport
+ *   instance) replays on the next — exactly the cross-redirect guarantee the
+ *   real transport gives.
+ * - Each instance can either answer requests (`respond = true`, a signer
+ *   return) or record them and never respond (`respond = false`, the load that
+ *   navigates away), so a test can simulate the first load that redirects and
+ *   the return load that completes.
+ *
+ * Reset all static state with {@link reset} in `beforeEach`; set
+ * {@link nextRespond} before constructing the `AuthClient` for a load.
+ */
+export class FakeUrlTransport implements Transport {
+  static instances: FakeUrlTransport[] = [];
+  static journal: unknown[] = [];
+  static nextRespond = true;
+
+  static reset(): void {
+    FakeUrlTransport.instances = [];
+    FakeUrlTransport.journal = [];
+    FakeUrlTransport.nextRespond = true;
+  }
+
+  static last(): FakeUrlTransport {
+    const t = FakeUrlTransport.instances.at(-1);
+    if (!t) throw new Error('No FakeUrlTransport instance exists');
+    return t;
+  }
+
+  readonly options: Record<string, unknown>;
+  readonly requests: JsonRpcRequest[] = [];
+  readonly #handlers: RequestHandler[] = [];
+  readonly #respond: boolean;
+  #cursor = 0;
+
+  constructor(options: Record<string, unknown> = {}) {
+    this.options = options;
+    this.#respond = FakeUrlTransport.nextRespond;
+    FakeUrlTransport.instances.push(this);
+  }
+
+  onRequest(handler: RequestHandler): void {
+    this.#handlers.push(handler);
+  }
+
+  async memoize<T>(produce: () => T | Promise<T>): Promise<T> {
+    const index = this.#cursor++;
+    if (index < FakeUrlTransport.journal.length) {
+      return FakeUrlTransport.journal[index] as T; // replay from an earlier load
+    }
+    const value = await produce();
+    FakeUrlTransport.journal[index] = value;
+    return value;
+  }
+
+  async establishChannel(): Promise<Channel> {
+    return new FakeUrlChannel(this.#handlers, this.requests, this.#respond);
+  }
+}
+
+class FakeUrlChannel implements Channel {
+  closed = false;
+  readonly #handlers: RequestHandler[];
+  readonly #requests: JsonRpcRequest[];
+  readonly #respond: boolean;
+  readonly #responseListeners = new Set<(response: JsonRpcResponse) => void>();
+  readonly #closeListeners = new Set<() => void>();
+
+  constructor(handlers: RequestHandler[], requests: JsonRpcRequest[], respond: boolean) {
+    this.#handlers = handlers;
+    this.#requests = requests;
+    this.#respond = respond;
+  }
+
+  addEventListener(event: 'close', listener: () => void): () => void;
+  addEventListener(event: 'response', listener: (response: JsonRpcResponse) => void): () => void;
+  addEventListener(
+    event: 'close' | 'response',
+    listener: ((response: JsonRpcResponse) => void) | (() => void),
+  ): () => void {
+    if (event === 'response') {
+      const fn = listener as (response: JsonRpcResponse) => void;
+      this.#responseListeners.add(fn);
+      return () => this.#responseListeners.delete(fn);
+    }
+    const fn = listener as () => void;
+    this.#closeListeners.add(fn);
+    return () => this.#closeListeners.delete(fn);
+  }
+
+  async send(request: JsonRpcRequest): Promise<void> {
+    if (this.closed) {
+      throw new Error('FakeUrlTransport: cannot send on a closed channel');
+    }
+    this.#requests.push(request);
+    // A load that navigates to the signer records the request but never
+    // receives a response in-context (the page unloads), so the request
+    // promise stays pending — exactly like the real redirect.
+    if (!this.#respond) return;
+    if (request.id === undefined || request.id === null) return;
+    for (const handler of this.#handlers) {
+      const response = await handler(request);
+      if (response === undefined) continue;
+      for (const listener of this.#responseListeners) listener(response);
+      return;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    for (const listener of this.#closeListeners) listener();
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **top-level redirect** sign-in flow to `AuthClient`, backed by the ICRC-167 URL transport in `@icp-sdk/signer@5.5.0`, alongside the default ICRC-29 popup flow. Selecting the transport is a single `transport` option — user code never touches the signer library.

## Changes

1. **`transport?: 'window' | 'redirect'` option** (default `'window'`). `'redirect'` builds a `UrlTransport` whose callback URL is the current page (`location.origin + location.pathname`); `'window'` keeps the existing `PostMessageTransport` (a separate tab/window, or a popup with `windowOpenerFeatures`). Purely additive — unset behaves exactly as before.
2. **`requestAttributes` nonce is now a callback** — `() => Promise<Uint8Array>` instead of a `Uint8Array | Promise<Uint8Array>` value. It has to be a callback so the redirect flow can journal the produced nonce and reuse the exact single-use bytes when the flow replays on the return load, instead of fetching a fresh nonce the signer never signed against.
3. **Session key survives the redirect.** In redirect mode `signIn` runs twice: the load that navigates to the identity provider, and the return load that replays the delegation minted for the first load's key. A per-flow key id is journaled via `transport.memoize`, the key kept in storage under a pending slot, restored on the return load, and removed once the delegation is persisted. Window mode is unchanged — a fresh key per sign-in.
4. **`AuthClient.memoize(produce)`** — exposes the transport's journal so callers can carry their own value across the redirect (e.g. a post-flow `next` URL captured from `location.search` on the first visit and replayed on the return load). In window mode it's a passthrough that just runs `produce`, so the same code works with either transport.
5. **Bumped `@icp-sdk/signer` `^5.4.0` → `^5.5.0`** (the release that ships `UrlTransport`).
6. **Upgrade guide** at `docs/src/content/docs/upgrading/v8.md`.

## Redirect flow usage

With `'redirect'` the page unloads on each step and the flow re-runs on the return load, so the sign-in code must run **directly on page load**, not deferred behind a click handler:

```ts
const authClient = new AuthClient({ transport: 'redirect' });

// A fresh visit starts the flow; the identity provider's return replays it to
// completion on the reload.
const identity = await authClient.signIn();
```

The callback URL is the current page (`location.origin + location.pathname`), which must be on an origin you control and declared in that origin's `/.well-known/ii-auth-callbacks` allow-list. Give each flow its own route.

## Testing

- `pnpm build`, `pnpm codestyle:check`, `publint --strict`: clean.
- `pnpm test`: 78 passing. Existing `requestAttributes` tests updated for the callback signature.
- New `tests/client/auth-client-redirect.test.ts` verifies the two cross-redirect invariants: the same session key is used on the return load (the `icrc34_delegation` request carries the same `publicKey` on both loads), and the same nonce is reused (the producer runs once, both requests carry identical `nonce`).

BREAKING CHANGE: `AuthClient.requestAttributes` now takes `nonce` as a callback `() => Promise<Uint8Array>` instead of a `Uint8Array | Promise<Uint8Array>` value. Pass the function that fetches the nonce (don't await it at the call site): `nonce: () => fetchNonce()`.
