### PR TITLE
fix(auth-client): keep the redirect flow batched and its derivation origin stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.5.0",
+    "@icp-sdk/signer": "^5.6.0",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@icp-sdk/signer':
-        specifier: ^5.5.0
-        version: 5.5.0(@icp-sdk/core@5.2.1)
+        specifier: ^5.6.0
+        version: 5.6.0(@icp-sdk/core@5.2.1)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -337,8 +337,8 @@ packages:
   '@icp-sdk/core@5.2.1':
     resolution: {integrity: sha512-FImRjnayCarov7vfr52QU3BO8tPAprbyl4O+0KWz4v7h8ZbKq15fhtdb53M6+ltUsCbWkP/lEgrQ4t1WhIAHjQ==}
 
-  '@icp-sdk/signer@5.5.0':
-    resolution: {integrity: sha512-ZYKGFL3RwYCPRhB8ej+LykFWT9366nYuYAOUeiTxEvPCyz+sft4j6JBCKftnnJM/x6CgZe/YGgfLCtYjDSH+Qw==}
+  '@icp-sdk/signer@5.6.0':
+    resolution: {integrity: sha512-zL8SR7YvMaTrEq6/8+ZX5wvTsXSUOm79dyZz7dj8MvHNZpH8pOKxE8QNmqThW4112EKES4ZLGxnAr3BJV1Oryg==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -1170,7 +1170,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       asn1js: 3.0.7
 
-  '@icp-sdk/signer@5.5.0(@icp-sdk/core@5.2.1)':
+  '@icp-sdk/signer@5.6.0(@icp-sdk/core@5.2.1)':
     dependencies:
       '@icp-sdk/core': 5.2.1
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -216,16 +216,14 @@ export class AuthClient {
 
     this.#signer = new Signer({
       transport,
-      // In the redirect flow, journal the derivation origin so it survives the
-      // top-level redirect: the return load reconstructs this client from a
-      // query-less callback URL, so `options.derivationOrigin` (like the
-      // identity provider) is no longer available — the memoized value replays
-      // from the journal instead. `memoize` returns synchronously for a
-      // synchronous producer, so the value is usable directly here in the
-      // constructor. The window flow completes in one load and needs no journal.
-      derivationOrigin: this.#urlTransport
-        ? this.#urlTransport.memoize(() => options.derivationOrigin?.toString())
-        : options.derivationOrigin?.toString(),
+      // Journal the derivation origin so it survives the top-level redirect: the
+      // return load reconstructs this client from a query-less callback URL, so
+      // `options.derivationOrigin` (like the identity provider) is no longer
+      // available — the memoized value replays from the journal instead.
+      // `memoize` returns synchronously for a synchronous producer, so the value
+      // is usable directly here; in the window flow it is a passthrough that runs
+      // the producer without persisting anything.
+      derivationOrigin: this.memoize(() => options.derivationOrigin?.toString()),
     });
 
     this.#registerDefaultIdleCallback();
@@ -474,10 +472,18 @@ export class AuthClient {
    *
    * In `'window'` mode there is no redirect, so this simply runs `produce` and
    * returns its result without persisting anything.
+   *
+   * Mirrors the producer's shape: a synchronous `produce` returns its value
+   * directly, an asynchronous one returns a promise. Awaiting the result is
+   * always safe (`await` on a non-promise is a no-op); the synchronous form lets
+   * a value be memoized where an `await` is not possible, such as in a
+   * constructor.
    * @param produce - Produces the value to journal on the first load.
    * @returns The produced value, or the journaled value on a replay load.
    */
-  async memoize<T>(produce: () => T | Promise<T>): Promise<T> {
+  memoize<T>(produce: () => Promise<T>): Promise<T>;
+  memoize<T>(produce: () => T): T;
+  memoize<T>(produce: () => T | Promise<T>): T | Promise<T> {
     if (this.#urlTransport) {
       return this.#urlTransport.memoize(produce);
     }

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -286,6 +286,12 @@ export class AuthClient {
     }> = this.#urlTransport
       ? this.#ensureSessionKeyForRedirectFlow(this.#urlTransport, keyType)
       : this.#ensureSessionKeyForWindowFlow(keyType).then((key) => ({ key }));
+    // The acquisition is started eagerly, before the awaits below. If one of
+    // those throws first, `sessionKeyPromise` is never awaited, so attach a
+    // no-op rejection handler now to keep a later acquisition failure from
+    // surfacing as an unhandled rejection. The `await` below still observes a
+    // rejection and propagates it when reached.
+    void sessionKeyPromise.catch(() => undefined);
 
     await this.#signer.openChannel();
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -216,7 +216,16 @@ export class AuthClient {
 
     this.#signer = new Signer({
       transport,
-      derivationOrigin: options.derivationOrigin?.toString(),
+      // In the redirect flow, journal the derivation origin so it survives the
+      // top-level redirect: the return load reconstructs this client from a
+      // query-less callback URL, so `options.derivationOrigin` (like the
+      // identity provider) is no longer available — the memoized value replays
+      // from the journal instead. `memoize` returns synchronously for a
+      // synchronous producer, so the value is usable directly here in the
+      // constructor. The window flow completes in one load and needs no journal.
+      derivationOrigin: this.#urlTransport
+        ? this.#urlTransport.memoize(() => options.derivationOrigin?.toString())
+        : options.derivationOrigin?.toString(),
     });
 
     this.#registerDefaultIdleCallback();
@@ -262,14 +271,27 @@ export class AuthClient {
    * }
    */
   async signIn(options?: AuthClientSignInOptions): Promise<Identity> {
-    await this.#signer.openChannel();
-
     const maxTimeToLive = options?.maxTimeToLive ?? DEFAULT_MAX_TIME_TO_LIVE;
     const keyType = this.#options.keyType ?? ECDSA_KEY_LABEL;
 
-    const { key, pendingKeySlot } = this.#urlTransport
-      ? await this.#ensureSessionKeyForRedirectFlow(this.#urlTransport, keyType)
-      : { key: await this.#ensureSessionKeyForWindowFlow(keyType) };
+    // Start session-key acquisition BEFORE opening the channel, awaiting it only
+    // after. In the redirect flow the acquisition's first `transport.memoize`
+    // runs synchronously when invoked, so its in-flight bump lands in the same
+    // tick `signIn` is called — holding the transport's batch flush from the
+    // very start of the flow rather than only after the `openChannel` await.
+    // Under `Promise.all([signIn, requestAttributes])` this is what keeps a
+    // faster concurrent request from flushing before this flow's delegation
+    // request is buffered.
+    const sessionKeyPromise: Promise<{
+      key: SignIdentity | PartialIdentity;
+      pendingKeySlot?: string;
+    }> = this.#urlTransport
+      ? this.#ensureSessionKeyForRedirectFlow(this.#urlTransport, keyType)
+      : this.#ensureSessionKeyForWindowFlow(keyType).then((key) => ({ key }));
+
+    await this.#signer.openChannel();
+
+    const { key, pendingKeySlot } = await sessionKeyPromise;
 
     const delegationChain = await this.#signer.requestDelegation({
       publicKey: key.getPublicKey(),
@@ -333,13 +355,35 @@ export class AuthClient {
     const keyId = await transport.memoize(() => globalThis.crypto.randomUUID());
     const pendingKeySlot = `${PENDING_KEY_PREFIX}${keyId}`;
 
-    const restored = await restoreKeyAt(this.#storage, pendingKeySlot);
-    if (restored) {
-      return { key: restored, pendingKeySlot };
-    }
+    // Acquire the per-flow key inside a `memoize` producer so the transport
+    // holds its batch flush across the (async) key restore/generate + storage
+    // write. The transport coalesces concurrently issued requests into one
+    // redirect by flushing on a macrotask once no memoize producer is in
+    // flight; without this hold, a faster concurrent request (e.g. the nonce
+    // path of `requestAttributes`) buffers first and trips that flush before
+    // this flow's delegation request — issued only once the key is ready — is
+    // buffered, splitting what should be one redirect into two.
+    //
+    // The key is captured in a closure, not read back after the producer: on
+    // the FIRST load the producer sets `acquired`, so the delegation request
+    // that follows is issued with no intervening storage read — a read there
+    // would re-open the very flush gap this closes. The producer is skipped on
+    // the replay load (its result is journaled), where the key is instead
+    // restored from storage. Only the id is journaled; the key lives in storage.
+    let acquired: SignIdentity | PartialIdentity | null = null;
+    await transport.memoize(async () => {
+      acquired = await restoreKeyAt(this.#storage, pendingKeySlot);
+      if (acquired === null) {
+        acquired = await generateKey(keyType);
+        await this.#storage.set(pendingKeySlot, serializeKey(acquired));
+      }
+      return keyId;
+    });
 
-    const key = await generateKey(keyType);
-    await this.#storage.set(pendingKeySlot, serializeKey(key));
+    const key = acquired ?? (await restoreKeyAt(this.#storage, pendingKeySlot));
+    if (key === null) {
+      throw new Error('Session key missing after acquisition');
+    }
     return { key, pendingKeySlot };
   }
 

--- a/tests/client/auth-client-redirect.test.ts
+++ b/tests/client/auth-client-redirect.test.ts
@@ -111,10 +111,41 @@ describe('AuthClient redirect (UrlTransport) sign-in', () => {
 
     expect(identity.getPrincipal().isAnonymous()).toBe(false);
     expect(FakeUrlTransport.last().requests[0]?.method).toBe('icrc34_delegation');
-    // The key id was journaled via `memoize`, and the pending key was removed
-    // once the delegation was persisted.
-    expect(FakeUrlTransport.journal).toHaveLength(1);
+    // The flow journals values that replay across the redirect: the (unset)
+    // derivation origin from construction, the session key id, and the
+    // key-acquisition step that holds the batch so the delegation isn't split
+    // off from a concurrent request. The pending key is removed once the
+    // delegation is persisted.
+    expect(FakeUrlTransport.journal).toHaveLength(3);
+    expect(FakeUrlTransport.journal[0]).toBeUndefined(); // derivation origin unset
     expect(pendingSlots(storage)).toEqual([]);
+  });
+
+  it('journals the derivation origin so it survives the redirect', async () => {
+    const storage = createSharedStorage();
+    const DERIVATION = 'https://derivation.example.com';
+
+    // Load 1: derivation origin supplied — forwarded on the request and journaled.
+    FakeUrlTransport.nextRespond = false;
+    const client1 = new AuthClient({
+      transport: 'redirect',
+      derivationOrigin: DERIVATION,
+      storage,
+    });
+    handleSignIn(FakeUrlTransport.last());
+    const pending1 = client1.signIn().catch(() => undefined); // navigates away
+    await flush();
+    expect(FakeUrlTransport.last().requests[0]?.params?.icrc95DerivationOrigin).toBe(DERIVATION);
+
+    // Load 2: the callback URL has no query, so no derivation origin is passed
+    // to the reconstructed client — the memoized value replays, so the request
+    // still carries the original derivation origin.
+    FakeUrlTransport.nextRespond = true;
+    const client2 = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    await client2.signIn();
+    expect(FakeUrlTransport.last().requests[0]?.params?.icrc95DerivationOrigin).toBe(DERIVATION);
+    void pending1;
   });
 
   it('derives the callback URL from the current location', () => {
@@ -181,7 +212,9 @@ describe('AuthClient redirect (UrlTransport) requestAttributes', () => {
 
     expect(thunk).toHaveBeenCalledOnce();
     expect(FakeUrlTransport.last().requests[0]?.params?.nonce).toBe(toBase64(nonce));
-    expect(FakeUrlTransport.journal).toEqual([toBase64(nonce)]); // journaled as base64
+    // Slot 0 is the (unset) derivation origin journaled at construction; slot 1
+    // is the nonce, journaled as base64.
+    expect(FakeUrlTransport.journal).toEqual([undefined, toBase64(nonce)]);
   });
 
   it('reuses the memoized nonce across the redirect instead of re-fetching', async () => {

--- a/tests/client/fake-url-transport.ts
+++ b/tests/client/fake-url-transport.ts
@@ -72,14 +72,25 @@ export class FakeUrlTransport implements Transport {
     this.#handlers.push(handler);
   }
 
-  async memoize<T>(produce: () => T | Promise<T>): Promise<T> {
+  // Mirrors the real transport's polymorphic memoize: a sync producer returns
+  // synchronously (so a value can be read where `await` isn't possible, e.g. in
+  // a constructor), an async one returns a promise.
+  memoize<T>(produce: () => Promise<T>): Promise<T>;
+  memoize<T>(produce: () => T): T;
+  memoize<T>(produce: () => T | Promise<T>): T | Promise<T> {
     const index = this.#cursor++;
     if (index < FakeUrlTransport.journal.length) {
       return FakeUrlTransport.journal[index] as T; // replay from an earlier load
     }
-    const value = await produce();
-    FakeUrlTransport.journal[index] = value;
-    return value;
+    const produced = produce();
+    if (produced instanceof Promise) {
+      return produced.then((value) => {
+        FakeUrlTransport.journal[index] = value;
+        return value;
+      });
+    }
+    FakeUrlTransport.journal[index] = produced;
+    return produced;
   }
 
   async establishChannel(): Promise<Channel> {


### PR DESCRIPTION
Bumps `@icp-sdk/signer` to `^5.6.0` and fixes two `UrlTransport` redirect-flow issues. Both only surface with real network / keygen timing, so the e2e mocks passed while a **deployed 1-click SSO + attributes** flow hit both.

## 1. Batch the delegation with a concurrent request

`Promise.all([signIn(), requestAttributes()])` should produce **one** redirect carrying `[delegation, attributes]`. It instead split into two — and the second (a lone `icrc34_delegation`) failed on the provider.

Cause: the transport coalesces concurrently-issued requests by flushing on a `setTimeout(0)` macrotask once no `memoize` producer is in flight. `requestAttributes` buffers its request after a quick nonce memoize, but `signIn` only buffers its delegation after `openChannel` **and** an IndexedDB key restore/generate — work the flush didn't wait for. So the flush fired with only the attributes request buffered.

Fix: `signIn` now (a) starts session-key acquisition *before* `openChannel` (so the memoize registers in the same tick), and (b) acquires the key *inside* a `memoize` producer, capturing it in a closure so there's no post-producer storage read. The in-flight count stays raised across the keygen, holding the flush until the delegation is buffered too.

## 2. Preserve the derivation origin across the redirect

The return load reconstructs `AuthClient` from a **query-less callback URL**, so `options.derivationOrigin` (like the identity provider) is gone. A re-issued request would drop it.

Fix: journal it — `derivationOrigin: this.#urlTransport.memoize(() => options.derivationOrigin?.toString())`. This relies on 5.6.0's `memoize` returning **synchronously** for a sync producer, so it's usable directly in the constructor. On replay the original value comes back from the journal. The memoize is unconditional (calling it only when set would desync the call-order journal between the fresh and return loads). The window flow is unaffected — it passes `derivationOrigin` directly.

## Tests

`tests/client/auth-client-redirect.test.ts`: added a derivation-origin-survives-redirect test; updated the journal-shape assertions for the new slots. The fake transport now mirrors 5.6.0's polymorphic `memoize`. Full suite green (81), `tsc` + biome clean.

## Requires

`@icp-sdk/signer@5.6.0` (the polymorphic `memoize` + redirect-target persistence).