### PR TITLE
fix: expire and sweep abandoned pending redirect session keys

### DIFF
--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -336,10 +336,16 @@ export class AuthClient {
     await persistKey(this.#storage, key);
 
     // The flow is complete: the delegation is bound to this key and stored, so
-    // the per-flow pending copy is no longer needed.
+    // the per-flow pending copy is no longer needed. Best-effort — the user is
+    // already signed in, so a cleanup failure must not fail signIn(); a later
+    // flow sweeps whatever is left behind.
     if (pendingKeySlot !== undefined) {
-      await this.#storage.remove(pendingKeySlot);
-      await unregisterPendingKey(this.#storage, pendingKeySlot);
+      try {
+        await this.#storage.remove(pendingKeySlot);
+        await unregisterPendingKey(this.#storage, pendingKeySlot);
+      } catch {
+        // ignore
+      }
     }
 
     return this.#identity;
@@ -393,8 +399,11 @@ export class AuthClient {
       acquired = await restoreKeyAt(this.#storage, pendingKeySlot);
       if (acquired === null) {
         acquired = await generateKey(keyType);
-        await this.#storage.set(pendingKeySlot, serializeKey(acquired));
+        // Register before writing the key: if the write then fails, a stray
+        // registry entry is harmless (swept on expiry), whereas a key with no
+        // registry entry would leak un-sweepably.
         await sweepAndRegisterPendingKey(this.#storage, pendingKeySlot, Date.now());
+        await this.#storage.set(pendingKeySlot, serializeKey(acquired));
       }
       return keyId;
     });
@@ -678,27 +687,26 @@ async function restoreKey(
   }
 }
 
-/**
- * Loads a session key from a specific storage slot, deserializing by stored
- * shape (`CryptoKeyPair` → ECDSA, JSON string → Ed25519). Unlike
- * {@link restoreKey} it does not migrate from localStorage — it reads only the
- * given slot, as used for a redirect flow's per-flow pending key.
- * @param storage - The storage backend.
- * @param storageKey - The slot to read.
- */
+// Reads the pending-key registry, dropping malformed entries. The value comes
+// from storage, so guard against corruption: keep only real pending-key slots
+// with a finite expiry (a NaN expiry compares false forever and never sweeps;
+// a foreign slot would make the sweep remove an unrelated storage key).
 async function readPendingRegistry(storage: AuthClientStorage): Promise<PendingKeyEntry[]> {
   const raw = await storage.get(PENDING_KEYS_REGISTRY_KEY);
   if (typeof raw !== 'string') return [];
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (entry): entry is PendingKeyEntry =>
-        typeof entry === 'object' &&
-        entry !== null &&
-        typeof (entry as PendingKeyEntry).slot === 'string' &&
-        typeof (entry as PendingKeyEntry).expiresAt === 'number',
-    );
+    return parsed.filter((entry): entry is PendingKeyEntry => {
+      if (typeof entry !== 'object' || entry === null) return false;
+      const { slot, expiresAt } = entry as PendingKeyEntry;
+      return (
+        typeof slot === 'string' &&
+        slot.startsWith(PENDING_KEY_PREFIX) &&
+        typeof expiresAt === 'number' &&
+        Number.isFinite(expiresAt)
+      );
+    });
   } catch {
     return [];
   }
@@ -744,6 +752,14 @@ async function unregisterPendingKey(storage: AuthClientStorage, slot: string): P
   }
 }
 
+/**
+ * Loads a session key from a specific storage slot, deserializing by stored
+ * shape (`CryptoKeyPair` → ECDSA, JSON string → Ed25519). Unlike
+ * {@link restoreKey} it does not migrate from localStorage — it reads only the
+ * given slot, as used for a redirect flow's per-flow pending key.
+ * @param storage - The storage backend.
+ * @param storageKey - The slot to read.
+ */
 async function restoreKeyAt(
   storage: AuthClientStorage,
   storageKey: string,

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -42,6 +42,19 @@ const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 // is persisted. See AuthClient.#acquireSessionKey.
 const PENDING_KEY_PREFIX = 'ic-auth-pending-key:';
 
+// The storage backend has no key enumeration, so pending-key slots are tracked
+// explicitly here: an abandoned flow never removes its key, so a later flow
+// prunes expired orphans by slot instead of leaking them forever.
+const PENDING_KEYS_REGISTRY_KEY = 'ic-auth-pending-keys';
+// Past the URL transport's ~10-min flow window the flow can't resume, so a
+// pending key older than this is treated as abandoned.
+const PENDING_KEY_TTL_MS = 10 * 60 * 1000;
+
+interface PendingKeyEntry {
+  slot: string;
+  expiresAt: number;
+}
+
 export type OpenIdProvider = 'google' | 'apple' | 'microsoft';
 
 export const OPENID_PROVIDER_URLS = {
@@ -326,6 +339,7 @@ export class AuthClient {
     // the per-flow pending copy is no longer needed.
     if (pendingKeySlot !== undefined) {
       await this.#storage.remove(pendingKeySlot);
+      await unregisterPendingKey(this.#storage, pendingKeySlot);
     }
 
     return this.#identity;
@@ -380,6 +394,7 @@ export class AuthClient {
       if (acquired === null) {
         acquired = await generateKey(keyType);
         await this.#storage.set(pendingKeySlot, serializeKey(acquired));
+        await sweepAndRegisterPendingKey(this.#storage, pendingKeySlot, Date.now());
       }
       return keyId;
     });
@@ -671,6 +686,64 @@ async function restoreKey(
  * @param storage - The storage backend.
  * @param storageKey - The slot to read.
  */
+async function readPendingRegistry(storage: AuthClientStorage): Promise<PendingKeyEntry[]> {
+  const raw = await storage.get(PENDING_KEYS_REGISTRY_KEY);
+  if (typeof raw !== 'string') return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is PendingKeyEntry =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as PendingKeyEntry).slot === 'string' &&
+        typeof (entry as PendingKeyEntry).expiresAt === 'number',
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function writePendingRegistry(
+  storage: AuthClientStorage,
+  entries: PendingKeyEntry[],
+): Promise<void> {
+  if (entries.length === 0) {
+    await storage.remove(PENDING_KEYS_REGISTRY_KEY);
+    return;
+  }
+  await storage.set(PENDING_KEYS_REGISTRY_KEY, JSON.stringify(entries));
+}
+
+// Removes expired pending-key slots, then registers `slot` with a fresh expiry.
+async function sweepAndRegisterPendingKey(
+  storage: AuthClientStorage,
+  slot: string,
+  now: number,
+): Promise<void> {
+  const entries = await readPendingRegistry(storage);
+  const live: PendingKeyEntry[] = [];
+  for (const entry of entries) {
+    if (entry.slot === slot) continue; // re-registered with a fresh expiry below
+    if (entry.expiresAt <= now) {
+      await storage.remove(entry.slot);
+    } else {
+      live.push(entry);
+    }
+  }
+  live.push({ slot, expiresAt: now + PENDING_KEY_TTL_MS });
+  await writePendingRegistry(storage, live);
+}
+
+// Drops a slot from the pending-key registry once its flow completes.
+async function unregisterPendingKey(storage: AuthClientStorage, slot: string): Promise<void> {
+  const entries = await readPendingRegistry(storage);
+  const remaining = entries.filter((entry) => entry.slot !== slot);
+  if (remaining.length !== entries.length) {
+    await writePendingRegistry(storage, remaining);
+  }
+}
+
 async function restoreKeyAt(
   storage: AuthClientStorage,
   storageKey: string,

--- a/tests/client/auth-client-redirect.test.ts
+++ b/tests/client/auth-client-redirect.test.ts
@@ -139,6 +139,43 @@ describe('AuthClient redirect (UrlTransport) sign-in', () => {
     expect(storage.map.has('ic-auth-pending-keys')).toBe(false);
   });
 
+  it('ignores corrupted registry entries (foreign slot, non-finite expiry)', async () => {
+    const storage = createSharedStorage();
+    // A registry corrupted with an entry pointing at an unrelated storage key
+    // and one with a NaN expiry — neither is a valid pending-key entry.
+    storage.map.set('ic-delegation', JSON.stringify({ not: 'a pending key' }));
+    storage.map.set(
+      'ic-auth-pending-keys',
+      JSON.stringify([
+        { slot: 'ic-delegation', expiresAt: Date.now() - 1 }, // foreign slot, "expired"
+        { slot: `${PENDING_KEY_PREFIX}nan`, expiresAt: Number.NaN }, // never-expiring
+      ]),
+    );
+
+    const client = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    await client.signIn();
+
+    // The sweep must not touch a key that was never a pending slot.
+    expect(storage.map.get('ic-delegation')).toBe(JSON.stringify({ not: 'a pending key' }));
+  });
+
+  it('completes sign-in even if pending-key cleanup fails', async () => {
+    const storage = createSharedStorage();
+    const remove = storage.remove;
+    storage.remove = async (key) => {
+      if (key.startsWith(PENDING_KEY_PREFIX)) throw new Error('storage unavailable');
+      return remove(key);
+    };
+
+    const client = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    const identity = await client.signIn();
+
+    // Cleanup of the completed flow's pending key failed, but auth succeeded.
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+  });
+
   it('journals the derivation origin so it survives the redirect', async () => {
     const storage = createSharedStorage();
     const DERIVATION = 'https://derivation.example.com';

--- a/tests/client/auth-client-redirect.test.ts
+++ b/tests/client/auth-client-redirect.test.ts
@@ -121,6 +121,24 @@ describe('AuthClient redirect (UrlTransport) sign-in', () => {
     expect(pendingSlots(storage)).toEqual([]);
   });
 
+  it('sweeps expired pending keys abandoned by earlier flows', async () => {
+    const storage = createSharedStorage();
+    const staleSlot = `${PENDING_KEY_PREFIX}abandoned`;
+    storage.map.set(staleSlot, JSON.stringify({ stale: 'key' }));
+    storage.map.set(
+      'ic-auth-pending-keys',
+      JSON.stringify([{ slot: staleSlot, expiresAt: Date.now() - 1 }]),
+    );
+
+    const client = new AuthClient({ transport: 'redirect', storage });
+    handleSignIn(FakeUrlTransport.last());
+    await client.signIn();
+
+    expect(storage.map.has(staleSlot)).toBe(false);
+    expect(pendingSlots(storage)).toEqual([]);
+    expect(storage.map.has('ic-auth-pending-keys')).toBe(false);
+  });
+
   it('journals the derivation origin so it survives the redirect', async () => {
     const storage = createSharedStorage();
     const DERIVATION = 'https://derivation.example.com';


### PR DESCRIPTION
## Problem

`#ensureSessionKeyForRedirectFlow` writes the per-flow session key to `ic-auth-pending-key:<uuid>` and removes it only after `signIn` completes. A flow the user **abandons at the identity provider never completes**, so the slot persists — and with a fresh `uuid` per attempt they **accumulate without bound**. For the default ECDSA type the value is a non-extractable `CryptoKeyPair` (storage bloat only), but with `keyType: 'Ed25519'` `serializeKey` stores `JSON.stringify(key.toJSON())` — the **raw private key** — so an RP on `LocalStorage` leaves raw keys at rest indefinitely. II has `expiresAt` + a sweep for its equivalent; AuthClient had neither.

## Fix

Track pending-key slots with an expiry in a small **registry** entry (`ic-auth-pending-keys`). The `AuthClientStorage` interface has no key enumeration, so a registry is how a later flow discovers earlier orphans without it; its value carries **no key material**, only slot names and timestamps.

- Each new redirect flow **sweeps** registry entries past their `~10-minute` window (matching the URL transport's default flow timeout, after which the flow can no longer resume) — removing the orphaned key slots — and **registers** its own.
- Completion removes the slot **and** its registry entry.

So an abandoned flow's key is reclaimed by the next flow instead of lingering forever.

## Verification

`tsc`, `vitest run` (82 tests, incl. a new "sweeps expired pending keys abandoned by earlier flows"), `biome check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)