### PR TITLE
fix: bump @icp-sdk/signer to 5.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@icp-sdk/core": "^5"
   },
   "dependencies": {
-    "@icp-sdk/signer": "^5.6.1",
+    "@icp-sdk/signer": "^5.6.2",
     "idb": "^7.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@icp-sdk/signer':
-        specifier: ^5.6.1
-        version: 5.6.1(@icp-sdk/core@5.4.0)
+        specifier: ^5.6.2
+        version: 5.6.2(@icp-sdk/core@5.4.0)
       idb:
         specifier: ^7.1.1
         version: 7.1.1
@@ -337,8 +337,8 @@ packages:
   '@icp-sdk/core@5.4.0':
     resolution: {integrity: sha512-yedhCkHIhCxI65W8id99Mi8fUgSyqKSTbD57AphquNcFV2/3Rjykng0/6H08mHswKydDcv6Y0+e8aPdrznewCw==}
 
-  '@icp-sdk/signer@5.6.1':
-    resolution: {integrity: sha512-Dd3ds6F6dw1CoOvKhyY4RLwFl/VC1ZITSVcZm+4kYp5VtHp7Q8pTL1Qb74W8/1FIRs/udTmCkGEcTR6tb6rdcA==}
+  '@icp-sdk/signer@5.6.2':
+    resolution: {integrity: sha512-QYqArHpe+uTHMEEoj7w/ET2hKSarsCBbvcQEs+GJrdIcMIm/gNIsFIrJVRB6YIPlgROYNkiK4ZjfNHMZsK5CyQ==}
     peerDependencies:
       '@icp-sdk/core': ^5
 
@@ -1179,7 +1179,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       asn1js: 3.0.10
 
-  '@icp-sdk/signer@5.6.1(@icp-sdk/core@5.4.0)':
+  '@icp-sdk/signer@5.6.2(@icp-sdk/core@5.4.0)':
     dependencies:
       '@icp-sdk/core': 5.4.0
 


### PR DESCRIPTION
Bumps `@icp-sdk/signer` from `^5.6.1` to `^5.6.2`.

`5.6.1` tightened delegation-chain validation but rejected a chain if **any** hop expired later than the requested `maxTimeToLive`. A chain is only usable while *every* hop is unexpired, so its effective lifetime is the **earliest** hop expiration — a longer hop alongside a short one grants no extra time. [dfinity/icp-js-signer#49](https://github.com/dfinity/icp-js-signer/pull/49) corrects the check to compare against that earliest expiration, released as [`5.6.2`](https://github.com/dfinity/icp-js-signer/releases/tag/5.6.2).

## Why this matters here

Any signer that inserts an intermediate key produces such a chain: a short-lived first hop bounding a long-lived hop that carries the relying party's session key. Internet Identity's ICRC-167 redirect transport does exactly this, so on `5.6.1` authenticating over it fails with:

```
Returned delegation expires later than the requested maxTimeToLive
```

The bump raises the declared minimum rather than relying on the existing `^5.6.1` range resolving upward, since `5.6.1` is specifically the broken version.

## Verification

Lockfile regenerated with the repository's pinned `pnpm@10.13.1` via corepack (PATH had 11.16.0, which would have risked a lockfile-format change), so the diff is limited to the specifier and the resolved version:

```
package.json   |  2 +-
pnpm-lock.yaml | 10 +++++-----
```

- `pnpm install --frozen-lockfile` — clean.
- `vitest run` — **88 passed**, no type errors.
- `biome check` — clean.
- `pnpm build` + `publint --strict` — all good.
