### PR TITLE
feat: share one session across origins with a shared session storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 Then point each origin at it:
 
 ```typescript
-import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
-import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
+import { AuthClient, SharedSessionStorage, SyncCookieStorage } from '@icp-sdk/auth/client';
 
 const authClient = new AuthClient({
   storage: new SharedSessionStorage({ url: 'https://auth.example.com/shared-session.html' }),

--- a/README.md
+++ b/README.md
@@ -71,17 +71,14 @@ const authClient = new AuthClient({
 
 ### Sharing One Session Across Origins
 
-Serve an application from several origins — `a.example.com`, `b.example.com` — with a single sign-in and a single principal.
+Serve an application from several origins — `docs.example.com`, `chat.example.com` — with a single sign-in and a single principal.
 
-Deploy a page that hosts the session:
+Deploy a page that hosts the session on your derivation origin:
 
 ```typescript
 import { serveSharedSession } from '@icp-sdk/auth/shared-session';
 
-serveSharedSession({
-  derivationOrigin: 'https://example.com',
-  canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
-});
+serveSharedSession();
 ```
 
 Then point each origin at it:
@@ -91,13 +88,13 @@ import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
 import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 
 const authClient = new AuthClient({
-  storage: new SharedSessionStorage({ url: 'https://example.com/shared-session.html' }),
+  storage: new SharedSessionStorage({ url: 'https://auth.example.com/shared-session.html' }),
   syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
-  derivationOrigin: 'https://example.com',
+  derivationOrigin: 'https://auth.example.com',
 });
 ```
 
-Each origin must be listed in the derivation origin's `.well-known/ii-alternative-origins` record. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
+Each origin must be listed in `https://auth.example.com/.well-known/ii-alternative-origins`. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
 
 ### Requesting Identity Attributes
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ const authClient = new AuthClient({
 
 ### Sharing One Session Across Origins
 
-Serve an application from several origins — `docs.example.com`, `chat.example.com` — with a single sign-in and a single principal.
+Give several apps under one custom domain — `docs.example.com`, `chat.example.com` — the same principal and the same sign-in state.
 
-Deploy a page that hosts the session on your derivation origin:
+Deploy a page that hosts the session:
 
 ```typescript
 import { serveSharedSession } from '@icp-sdk/auth/shared-session';
 
-serveSharedSession();
+serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 ```
 
 Then point each origin at it:
@@ -94,7 +94,7 @@ const authClient = new AuthClient({
 });
 ```
 
-Each origin must be listed in `https://auth.example.com/.well-known/ii-alternative-origins`. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
+Each app must be listed in the derivation origin's `.well-known/ii-alternative-origins` record. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
 
 ### Requesting Identity Attributes
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,16 @@ serveSharedSession({
 });
 ```
 
-Then point the other origins at that page:
+Then point the other origins at that page, as a storage backend:
 
 ```typescript
+import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
+
 const authClient = new AuthClient({
-  sharedSessionHub: { url: 'https://example.com/shared-session.html' },
+  storage: new SharedSessionStorage({
+    hub: { url: 'https://example.com/shared-session.html' },
+    derivationOrigin: 'https://example.com',
+  }),
   derivationOrigin: 'https://example.com',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const authClient = new AuthClient({
 });
 ```
 
-Each app must be listed in the derivation origin's `.well-known/ii-alternative-origins` record. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
+Each app must be listed in the derivation origin's `.well-known/ii-alternative-origins` record. See the [shared session guide](https://js.icp.build/auth/shared-session).
 
 ### Requesting Identity Attributes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 
 const authClient = new AuthClient({
   storage: new SharedSessionStorage({
-    hub: { url: 'https://example.com/shared-session.html' },
+    url: 'https://example.com/shared-session.html',
     derivationOrigin: 'https://example.com',
   }),
   derivationOrigin: 'https://example.com',

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ const authClient = new AuthClient({
 
 ### Sharing One Session Across Origins
 
-Serve an application from several origins — `a.example.com`, `b.example.com` — with a single sign-in and a single principal. One origin holds the session and serves it to the others; nothing is stored on them, and the session never travels in an HTTP header.
+Serve an application from several origins — `a.example.com`, `b.example.com` — with a single sign-in and a single principal.
 
-Deploy a page on the origin that holds it:
+Deploy a page that hosts the session:
 
 ```typescript
 import { serveSharedSession } from '@icp-sdk/auth/shared-session';
@@ -84,21 +84,20 @@ serveSharedSession({
 });
 ```
 
-Then point the other origins at that page, as a storage backend:
+Then point each origin at it:
 
 ```typescript
+import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
 import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 
 const authClient = new AuthClient({
-  storage: new SharedSessionStorage({
-    url: 'https://example.com/shared-session.html',
-    derivationOrigin: 'https://example.com',
-  }),
+  storage: new SharedSessionStorage({ url: 'https://example.com/shared-session.html' }),
+  syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
   derivationOrigin: 'https://example.com',
 });
 ```
 
-Which origins may read the session is decided by the derivation origin's `.well-known/ii-alternative-origins` record — the same record Internet Identity reads when deriving their principal. See the [shared session guide](https://js.icp.build/auth/shared-session) for deployment requirements and browser behaviour.
+Each origin must be listed in the derivation origin's `.well-known/ii-alternative-origins` record. See the [shared session guide](https://js.icp.build/auth/shared-session) for the full setup.
 
 ### Requesting Identity Attributes
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ const authClient = new AuthClient({
 });
 ```
 
+### Sharing One Session Across Origins
+
+Serve an application from several origins — `a.example.com`, `b.example.com` — with a single sign-in and a single principal. One origin holds the session and serves it to the others; nothing is stored on them, and the session never travels in an HTTP header.
+
+Deploy a page on the origin that holds it:
+
+```typescript
+import { serveSharedSession } from '@icp-sdk/auth/shared-session';
+
+serveSharedSession({
+  derivationOrigin: 'https://example.com',
+  canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
+});
+```
+
+Then point the other origins at that page:
+
+```typescript
+const authClient = new AuthClient({
+  sharedSessionHub: { url: 'https://example.com/shared-session.html' },
+  derivationOrigin: 'https://example.com',
+});
+```
+
+Which origins may read the session is decided by the derivation origin's `.well-known/ii-alternative-origins` record — the same record Internet Identity reads when deriving their principal. See the [shared session guide](https://js.icp.build/auth/shared-session) for deployment requirements and browser behaviour.
+
 ### Requesting Identity Attributes
 
 Internet Identity can provide signed identity attributes (e.g., email) alongside authentication. Your backend canister initiates the flow by issuing a nonce tied to the action — this way, even if an attribute bundle is intercepted, it can't be replayed or used for a different action.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const authClient = new AuthClient({
 
 ### Sharing One Session Across Origins
 
-Give several apps under one custom domain — `docs.example.com`, `chat.example.com` — the same principal and the same sign-in state.
+Give several apps under one custom domain the same principal and the same sign-in state, so that `docs.example.com` and `chat.example.com` sign in once as the same user.
 
 Deploy a page that hosts the session:
 

--- a/docs/src/content/docs/_sidebar.json
+++ b/docs/src/content/docs/_sidebar.json
@@ -4,7 +4,8 @@
     "items": [
       { "label": "Overview", "link": "/" },
       { "label": "Installation", "link": "/installation" },
-      { "label": "Quick Start", "link": "/quick-start" }
+      { "label": "Quick Start", "link": "/quick-start" },
+      { "label": "Shared Session", "link": "/shared-session" }
     ]
   },
   {
@@ -16,6 +17,14 @@
         "autogenerate": {
           "collapsed": true,
           "directory": "api/client/"
+        }
+      },
+      {
+        "label": "Shared Session",
+        "collapsed": true,
+        "autogenerate": {
+          "collapsed": true,
+          "directory": "api/shared-session/"
         }
       }
     ]

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -28,7 +28,7 @@ serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 
 ## 2. Authorize each app
 
-The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record:
+The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://docs.internetcomputer.org/references/internet-identity-spec/#alternative-frontend-origins) record:
 
 ```json
 { "alternativeOrigins": ["https://docs.example.com", "https://chat.example.com"] }

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -66,7 +66,11 @@ Signing out on any origin clears the shared store, so every origin loses the ses
 
 ## Checking for a session
 
-`isAuthenticated()` answers synchronously from a cache in the local origin's `localStorage`, which a shared session cannot populate before it has been read once. On an origin's first load the cache is empty, so prefer the identity itself:
+`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store instead — `localStorage` normally, and a cookie scoped to the derivation origin's domain when `sharedSessionHub` is set.
+
+The cookie is what makes the answer correct across origins. It holds one non-secret value, a timestamp, and its `Max-Age` matches the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
+
+It is a hint, not authority. Every subdomain can write it and nothing records which one did, so treat `isAuthenticated()` as a synchronous guess suitable for deciding what to render. The identity itself is always fetched from the shared store and verified:
 
 ```typescript
 const identity = await authClient.getIdentity();
@@ -75,7 +79,9 @@ if (identity.getPrincipal().isAnonymous()) {
 }
 ```
 
-After that first restore the cache is written, and `isAuthenticated()` is accurate on subsequent loads of that origin. One case stays approximate: if another origin signs out, this origin reports a session until it next restores and finds the store empty, at which point the cache is cleared.
+A cookie can only be scoped to the current host or a domain above it, so this needs the derivation origin to be a **parent** of the consuming origins — `https://example.com` for clients on `a.example.com` and `b.example.com`. With a sibling derivation origin (`auth.example.com` alongside `a.example.com`) the cookie is unreachable, so `localStorage` is used instead and `isAuthenticated()` is correct only after that origin has restored the session once.
+
+Supply `syncStorage` to override the choice entirely.
 
 ## Browser support
 

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -39,8 +39,7 @@ The derivation origin decides which origins may read the session. List them in i
 On `docs.example.com` and `chat.example.com` alike:
 
 ```typescript
-import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
-import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
+import { AuthClient, SharedSessionStorage, SyncCookieStorage } from '@icp-sdk/auth/client';
 
 const authClient = new AuthClient({
   storage: new SharedSessionStorage({ url: 'https://auth.example.com/shared-session.html' }),

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -66,7 +66,7 @@ Signing out on any origin clears the shared store, so every origin loses the ses
 
 ## Checking for a session
 
-`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store instead — `localStorage` normally, and a cookie scoped to the derivation origin's domain when `sharedSessionHub` is set.
+`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store instead — `localStorage` normally, and a cookie scoped to the hub's domain when `sharedSessionHub` is set.
 
 The cookie is what makes the answer correct across origins. It holds one non-secret value, a timestamp, and its `Max-Age` matches the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
 
@@ -79,7 +79,7 @@ if (identity.getPrincipal().isAnonymous()) {
 }
 ```
 
-A cookie can only be scoped to the current host or a domain above it, so this needs the derivation origin to be a **parent** of the consuming origins — `https://example.com` for clients on `a.example.com` and `b.example.com`. With a sibling derivation origin (`auth.example.com` alongside `a.example.com`) the cookie is unreachable, so `localStorage` is used instead and `isAuthenticated()` is correct only after that origin has restored the session once.
+The cookie follows the **hub**, not the derivation origin: the hub is necessarily same-site with the origins it serves, while the derivation origin may be an unrelated domain. A cookie can only be scoped to the current host or a domain above it, so this needs the hub to be a **parent** of the consuming origins — `https://example.com` serving clients on `a.example.com` and `b.example.com`. With a sibling hub (`auth.example.com` alongside `a.example.com`) the cookie is unreachable, so `localStorage` is used instead and `isAuthenticated()` is correct only after that origin has restored the session once.
 
 Supply `syncStorage` to override the choice entirely.
 

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -3,23 +3,15 @@ title: Shared Session
 description: Share one sign-in across several origins of the same application.
 ---
 
-An `AuthClient` keeps its session in the storage of the origin it runs on, so an application served from `https://a.example.com` and `https://b.example.com` asks the user to sign in twice, and each origin receives a different principal.
+By default a session belongs to the origin it was created on, so an application served from `a.example.com` and `b.example.com` asks the user to sign in twice and gives each origin a different principal.
 
-A shared session solves both halves of that. One origin holds the session and serves it to the others over `postMessage`, and a `derivationOrigin` makes every origin derive the same principal.
+A shared session fixes both. One origin hosts the session, the others read it from there, and a `derivationOrigin` keeps the principal the same everywhere.
 
-Nothing is written on the origins that consume the session, and the session never travels in an HTTP header — unlike a cookie, which is sent with every request to the domain and readable by any script on it.
+You need three things: a page that hosts the session, an entry per origin in an Internet Identity record, and a few options on each client.
 
-## What authorizes an origin
+## 1. Host the session
 
-The set of origins allowed to read the session is the derivation origin's [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record — the same record Internet Identity reads when it derives a principal for an alternative origin.
-
-Reusing it is deliberate. Every origin in that record can already obtain a delegation for the derivation origin's principal by signing in with `derivationOrigin` set, so being listed there is already full authority over the account. Serving a stored session to exactly that set grants nothing further, and it leaves one list to maintain rather than two that can drift apart.
-
-Adding an entry to that record is therefore a security change, not configuration. Keep it to origins you deploy yourself.
-
-## Serving the session
-
-Deploy a page whose only job is to call `serveSharedSession`. It needs no markup and no user interaction.
+Deploy a page that calls `serveSharedSession`. It needs no markup and no interaction — put it on any origin you control that shares a domain with your app, such as `https://example.com/shared-session.html`.
 
 ```html
 <!doctype html>
@@ -37,71 +29,53 @@ serveSharedSession({
 });
 ```
 
-`derivationOrigin` must match what the clients are configured with; the hub refuses a client that disagrees, because the record it holds would not be the one governing that client's identity.
+| Option | Set it to |
+| --- | --- |
+| `derivationOrigin` | The origin whose principal your users get. Must resolve to a canister. Every client signs in with this same value. |
+| `canisterId` | The canister behind that derivation origin. Optional when this page is served from the derivation origin itself; otherwise set it, so the allow-list is read over a verified route. |
 
-Pass `canisterId` whenever the derivation origin is a different origin than the hub page. The record is then read through `https://<canisterId>.icp0.io`, where a boundary node verifies certification. Without it the record is read over the derivation origin's own domain, where anyone able to tamper with responses can widen the set of readers — a precaution Internet Identity itself takes when validating a derivation origin.
-
-Serve the page with a `frame-ancestors` header so unrelated sites cannot even load it:
+Serve the page with a header naming the origins allowed to embed it:
 
 ```
 Content-Security-Policy: frame-ancestors 'self' https://a.example.com https://b.example.com;
 ```
 
-That is defence in depth. The record above is what authorizes a reader, and it stays authoritative.
+## 2. Authorize each origin
 
-## Consuming the session
+Add every consuming origin to the derivation origin's [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record, served with `Access-Control-Allow-Origin: *`:
 
-A shared session is a storage backend, so it is passed as `storage`:
+```json
+{ "alternativeOrigins": ["https://a.example.com", "https://b.example.com"] }
+```
+
+This record is the only thing that decides who may read the session, so treat adding an entry as a security change and keep it to origins you deploy yourself. Internet Identity allows at most 10.
+
+## 3. Point each client at it
 
 ```typescript
-import { AuthClient } from '@icp-sdk/auth/client';
+import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
 import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 
-const DERIVATION_ORIGIN = 'https://example.com';
-
-const sharedSession = new SharedSessionStorage({
-  url: 'https://example.com/shared-session.html',
-  derivationOrigin: DERIVATION_ORIGIN,
-});
-
 const authClient = new AuthClient({
-  storage: sharedSession,
-  derivationOrigin: DERIVATION_ORIGIN,
+  storage: new SharedSessionStorage({ url: 'https://example.com/shared-session.html' }),
+  syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
+  derivationOrigin: 'https://example.com',
 });
 ```
 
-`SharedSessionStorage` requires `derivationOrigin`: without one, the same key yields a different principal on every origin, leaving a shared store holding an identity nobody else can use.
+| Option | Set it to |
+| --- | --- |
+| `storage` | A `SharedSessionStorage` pointing at the page from step 1. |
+| `derivationOrigin` | The same value that page was given. A different one silently stores a session no other origin can use. |
+| `syncStorage` | A `SyncCookieStorage` scoped to the domain your origins share, so `isAuthenticated()` is correct on first load. Optional — see below. |
 
-Pass the **same** derivation origin to both, as above. They are separate options, so nothing stops them differing — and if they do, this client signs in as one principal while its session is stored in a hub authorized for another. Keep it in one constant.
+`domain` must be your own domain or one above the current host, and cannot be a public suffix like `com`. Nothing needs to be served there. Assume one shared session per domain: a second one alongside it would overwrite the first's state, so give a staging deployment its own domain or leave `syncStorage` unset on it.
 
-Signing out on any origin clears the shared store, so every origin loses the session.
+Everything else is unchanged. `signIn()` and `signOut()` work as usual, and signing out on one origin ends the session on all of them.
 
 ## Checking for a session
 
-`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store, which defaults to `localStorage` — scoped to one origin, so an origin sharing a session has nothing to read until it has restored once.
-
-A cookie fixes that, being the only store that is both synchronous and visible across origins:
-
-```typescript
-import { SyncCookieStorage } from '@icp-sdk/auth/client';
-
-const authClient = new AuthClient({
-  storage: sharedSession,
-  syncStorage: new SyncCookieStorage({
-    domain: 'example.com',
-    derivationOrigin: DERIVATION_ORIGIN,
-  }),
-  derivationOrigin: DERIVATION_ORIGIN,
-});
-```
-
-`domain` is what the sharing origins have in common, and must be the current host or a domain above it — a browser rejects anything else, including a sibling subdomain, and refuses a public suffix outright. Nothing needs to be served at it: a hub on `auth.example.com` can scope its cookie to `example.com` even if nothing answers there.
-
-`derivationOrigin` becomes part of the cookie's name, so two shared sessions under one domain — a staging deployment beside production — do not write the same cookie and describe each other's state. It is the same constant the other two options take.
-
-The cookie holds one non-secret value, a timestamp, and its `Max-Age` comes from the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
-
-It is a hint, not authority. Every subdomain can write it and nothing records which one did, so treat `isAuthenticated()` as a synchronous guess suitable for deciding what to render. The identity itself is always fetched from the shared store and verified:
+`isAuthenticated()` is synchronous, so it reads a small cookie rather than the shared session itself. Treat it as a hint for deciding what to render — any script on your domain can change it. Use the identity when it matters:
 
 ```typescript
 const identity = await authClient.getIdentity();
@@ -110,21 +84,10 @@ if (identity.getPrincipal().isAnonymous()) {
 }
 ```
 
-Leave `syncStorage` unset and behaviour is unchanged from a single-origin app: correct on that origin, and correct on the others only once each has restored the session.
+Without `syncStorage`, `isAuthenticated()` returns `false` on an origin's first load until the session has been read once.
 
-## Browser support
+## Good to know
 
-The hub is a same-site iframe, so its storage is not partitioned: Chrome, Firefox, and Safari all key third-party storage on the top-level site, and every origin here shares one registrable domain. Cross-registrable-domain sharing is not supported — that storage is partitioned, and an entry in the record pointing outside your domain simply reads an empty store.
-
-Two consequences of relying on browser storage:
-
-- Safari deletes script-writable storage after seven days without interaction with the site, so a returning user may need to sign in again.
-- Private browsing keeps the session for the tab's lifetime only.
-
-Both surface as "no session", which `signIn()` recovers from.
-
-## Requirements
-
-- The derivation origin must resolve to a canister id, which Internet Identity requires in order to read its record.
-- Its record may list at most 10 origins.
-- Choose the derivation origin before launch. Every principal is derived from it, so changing it later gives every user a new identity with no path back to the old one.
+- Sharing works between origins on one domain. A different domain reads an empty session, even if it is listed in the record.
+- Safari clears browser storage after seven days without a visit, and private windows keep it only for the tab. Both look like no session, which `signIn()` recovers from.
+- Pick the derivation origin before launch. Every principal derives from it, so changing it later gives every user a new identity with no way back to the old one.

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -1,0 +1,95 @@
+---
+title: Shared Session
+description: Share one sign-in across several origins of the same application.
+---
+
+An `AuthClient` keeps its session in the storage of the origin it runs on, so an application served from `https://a.example.com` and `https://b.example.com` asks the user to sign in twice, and each origin receives a different principal.
+
+A shared session solves both halves of that. One origin holds the session and serves it to the others over `postMessage`, and a `derivationOrigin` makes every origin derive the same principal.
+
+Nothing is written on the origins that consume the session, and the session never travels in an HTTP header — unlike a cookie, which is sent with every request to the domain and readable by any script on it.
+
+## What authorizes an origin
+
+The set of origins allowed to read the session is the derivation origin's [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record — the same record Internet Identity reads when it derives a principal for an alternative origin.
+
+Reusing it is deliberate. Every origin in that record can already obtain a delegation for the derivation origin's principal by signing in with `derivationOrigin` set, so being listed there is already full authority over the account. Serving a stored session to exactly that set grants nothing further, and it leaves one list to maintain rather than two that can drift apart.
+
+Adding an entry to that record is therefore a security change, not configuration. Keep it to origins you deploy yourself.
+
+## Serving the session
+
+Deploy a page whose only job is to call `serveSharedSession`. It needs no markup and no user interaction.
+
+```html
+<!doctype html>
+<meta charset="utf-8" />
+<title>Shared session</title>
+<script type="module" src="/shared-session.js"></script>
+```
+
+```typescript
+import { serveSharedSession } from '@icp-sdk/auth/shared-session';
+
+serveSharedSession({
+  derivationOrigin: 'https://example.com',
+  canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
+});
+```
+
+`derivationOrigin` must match what the clients are configured with; the hub refuses a client that disagrees, because the record it holds would not be the one governing that client's identity.
+
+Pass `canisterId` whenever the derivation origin is a different origin than the hub page. The record is then read through `https://<canisterId>.icp0.io`, where a boundary node verifies certification. Without it the record is read over the derivation origin's own domain, where anyone able to tamper with responses can widen the set of readers — a precaution Internet Identity itself takes when validating a derivation origin.
+
+Serve the page with a `frame-ancestors` header so unrelated sites cannot even load it:
+
+```
+Content-Security-Policy: frame-ancestors 'self' https://a.example.com https://b.example.com;
+```
+
+That is defence in depth. The record above is what authorizes a reader, and it stays authoritative.
+
+## Consuming the session
+
+```typescript
+import { AuthClient } from '@icp-sdk/auth/client';
+
+const authClient = new AuthClient({
+  sharedSessionHub: { url: 'https://example.com/shared-session.html' },
+  derivationOrigin: 'https://example.com',
+});
+```
+
+`sharedSessionHub` requires `derivationOrigin` and replaces `storage`. Without a shared derivation origin the same key would yield a different principal on every origin, leaving a shared store holding an identity nobody else can use — so the type system requires the two together.
+
+Signing out on any origin clears the shared store, so every origin loses the session.
+
+## Checking for a session
+
+`isAuthenticated()` answers synchronously from a cache in the local origin's `localStorage`, which a shared session cannot populate before it has been read once. On an origin's first load the cache is empty, so prefer the identity itself:
+
+```typescript
+const identity = await authClient.getIdentity();
+if (identity.getPrincipal().isAnonymous()) {
+  await authClient.signIn();
+}
+```
+
+After that first restore the cache is written, and `isAuthenticated()` is accurate on subsequent loads of that origin. One case stays approximate: if another origin signs out, this origin reports a session until it next restores and finds the store empty, at which point the cache is cleared.
+
+## Browser support
+
+The hub is a same-site iframe, so its storage is not partitioned: Chrome, Firefox, and Safari all key third-party storage on the top-level site, and every origin here shares one registrable domain. Cross-registrable-domain sharing is not supported — that storage is partitioned, and an entry in the record pointing outside your domain simply reads an empty store.
+
+Two consequences of relying on browser storage:
+
+- Safari deletes script-writable storage after seven days without interaction with the site, so a returning user may need to sign in again.
+- Private browsing keeps the session for the tab's lifetime only.
+
+Both surface as "no session", which `signIn()` recovers from.
+
+## Requirements
+
+- The derivation origin must resolve to a canister id, which Internet Identity requires in order to read its record.
+- Its record may list at most 10 origins.
+- Choose the derivation origin before launch. Every principal is derived from it, so changing it later gives every user a new identity with no path back to the old one.

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -51,24 +51,55 @@ That is defence in depth. The record above is what authorizes a reader, and it s
 
 ## Consuming the session
 
+A shared session is a storage backend, so it is passed as `storage`:
+
 ```typescript
 import { AuthClient } from '@icp-sdk/auth/client';
+import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
+
+const DERIVATION_ORIGIN = 'https://example.com';
+
+const sharedSession = new SharedSessionStorage({
+  hub: { url: 'https://example.com/shared-session.html' },
+  derivationOrigin: DERIVATION_ORIGIN,
+});
 
 const authClient = new AuthClient({
-  sharedSessionHub: { url: 'https://example.com/shared-session.html' },
-  derivationOrigin: 'https://example.com',
+  storage: sharedSession,
+  derivationOrigin: DERIVATION_ORIGIN,
 });
 ```
 
-`sharedSessionHub` requires `derivationOrigin` and replaces `storage`. Without a shared derivation origin the same key would yield a different principal on every origin, leaving a shared store holding an identity nobody else can use — so the type system requires the two together.
+`SharedSessionStorage` requires `derivationOrigin`: without one, the same key yields a different principal on every origin, leaving a shared store holding an identity nobody else can use.
+
+Pass the **same** derivation origin to both, as above. They are separate options, so nothing stops them differing — and if they do, this client signs in as one principal while its session is stored in a hub authorized for another. Keep it in one constant.
 
 Signing out on any origin clears the shared store, so every origin loses the session.
 
 ## Checking for a session
 
-`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store instead — `localStorage` normally, and a cookie scoped to the hub's domain when `sharedSessionHub` is set.
+`isAuthenticated()` answers synchronously, so it cannot read the shared store: that one is asynchronous and belongs to another origin. It reads the delegation's expiration from a separate synchronous store, which defaults to `localStorage` — scoped to one origin, so an origin sharing a session has nothing to read until it has restored once.
 
-The cookie is what makes the answer correct across origins. It holds one non-secret value, a timestamp, and its `Max-Age` matches the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
+A cookie fixes that, being the only store that is both synchronous and visible across origins:
+
+```typescript
+import { SyncCookieStorage } from '@icp-sdk/auth/client';
+
+const authClient = new AuthClient({
+  storage: sharedSession,
+  syncStorage: new SyncCookieStorage({
+    domain: 'example.com',
+    namespace: sharedSession.hubOrigin,
+  }),
+  derivationOrigin: DERIVATION_ORIGIN,
+});
+```
+
+`domain` is what the sharing origins have in common, and must be the current host or a domain above it — a browser rejects anything else, including a sibling subdomain, and refuses a public suffix outright. Nothing needs to be served at it: a hub on `auth.example.com` can scope its cookie to `example.com` even if nothing answers there.
+
+`namespace` keeps two shared sessions under one domain from describing each other's state, which matters for a staging deployment beside production. `hubOrigin` identifies the session, since the hub is where it lives.
+
+The cookie holds one non-secret value, a timestamp, and its `Max-Age` comes from the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
 
 It is a hint, not authority. Every subdomain can write it and nothing records which one did, so treat `isAuthenticated()` as a synchronous guess suitable for deciding what to render. The identity itself is always fetched from the shared store and verified:
 
@@ -79,9 +110,7 @@ if (identity.getPrincipal().isAnonymous()) {
 }
 ```
 
-The cookie follows the **hub**, not the derivation origin: the hub is necessarily same-site with the origins it serves, while the derivation origin may be an unrelated domain. A cookie can only be scoped to the current host or a domain above it, so this needs the hub to be a **parent** of the consuming origins — `https://example.com` serving clients on `a.example.com` and `b.example.com`. With a sibling hub (`auth.example.com` alongside `a.example.com`) the cookie is unreachable, so `localStorage` is used instead and `isAuthenticated()` is correct only after that origin has restored the session once.
-
-Supply `syncStorage` to override the choice entirely.
+Leave `syncStorage` unset and behaviour is unchanged from a single-origin app: correct on that origin, and correct on the others only once each has restored the session.
 
 ## Browser support
 

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -3,7 +3,7 @@ title: Shared Session
 description: Share one sign-in across several origins of the same application.
 ---
 
-By default a session belongs to the origin it was created on, so an application served from `a.example.com` and `b.example.com` asks the user to sign in twice and gives each origin a different principal.
+By default a session belongs to the origin it was created on, so an application served from `docs.example.com` and `chat.example.com` asks the user to sign in twice and gives each origin a different principal.
 
 A shared session fixes both. One origin hosts the session, the others read it from there, and a `derivationOrigin` keeps the principal the same everywhere.
 
@@ -11,7 +11,7 @@ You need three things: a page that hosts the session, an entry per origin in an 
 
 ## 1. Host the session
 
-Deploy a page that calls `serveSharedSession`. It needs no markup and no interaction — put it on any origin you control that shares a domain with your app, such as `https://example.com/shared-session.html`.
+Deploy a page that calls `serveSharedSession`. It needs no markup and no interaction, and can live on any origin you control — for an app on `docs.example.com` and `chat.example.com`, a dedicated `https://auth.example.com/shared-session.html` keeps it away from your application code.
 
 ```html
 <!doctype html>
@@ -23,59 +23,59 @@ Deploy a page that calls `serveSharedSession`. It needs no markup and no interac
 ```typescript
 import { serveSharedSession } from '@icp-sdk/auth/shared-session';
 
-serveSharedSession({
-  derivationOrigin: 'https://example.com',
-  canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
-});
+serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 ```
 
-| Option | Set it to |
-| --- | --- |
-| `derivationOrigin` | The origin whose principal your users get. Must resolve to a canister. Every client signs in with this same value. |
-| `canisterId` | The canister behind that derivation origin. Optional when this page is served from the derivation origin itself; otherwise set it, so the allow-list is read over a verified route. |
+Set `derivationOrigin` to the origin whose principal your users get — the same value every client signs in with. It must resolve to a canister, which Internet Identity requires of a derivation origin.
 
 Serve the page with a header naming the origins allowed to embed it:
 
 ```
-Content-Security-Policy: frame-ancestors 'self' https://a.example.com https://b.example.com;
+Content-Security-Policy: frame-ancestors 'self' https://docs.example.com https://chat.example.com;
 ```
 
 ## 2. Authorize each origin
 
-Add every consuming origin to the derivation origin's [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record, served with `Access-Control-Allow-Origin: *`:
+Add every consuming origin to `https://auth.example.com/.well-known/ii-alternative-origins`, served with `Access-Control-Allow-Origin: *`:
 
 ```json
-{ "alternativeOrigins": ["https://a.example.com", "https://b.example.com"] }
+{ "alternativeOrigins": ["https://docs.example.com", "https://chat.example.com"] }
 ```
 
 This record is the only thing that decides who may read the session, so treat adding an entry as a security change and keep it to origins you deploy yourself. Internet Identity allows at most 10.
 
 ## 3. Point each client at it
 
+On `docs.example.com` and `chat.example.com` alike:
+
 ```typescript
 import { AuthClient, SyncCookieStorage } from '@icp-sdk/auth/client';
 import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 
 const authClient = new AuthClient({
-  storage: new SharedSessionStorage({ url: 'https://example.com/shared-session.html' }),
+  storage: new SharedSessionStorage({ url: 'https://auth.example.com/shared-session.html' }),
   syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
-  derivationOrigin: 'https://example.com',
+  derivationOrigin: 'https://auth.example.com',
 });
 ```
 
 | Option | Set it to |
 | --- | --- |
 | `storage` | A `SharedSessionStorage` pointing at the page from step 1. |
-| `derivationOrigin` | The same value that page was given. A different one silently stores a session no other origin can use. |
-| `syncStorage` | A `SyncCookieStorage` scoped to the domain your origins share, so `isAuthenticated()` is correct on first load. Optional — see below. |
+| `derivationOrigin` | The origin that page is served from. A different value silently stores a session no other origin can use. |
+| `syncStorage` | A `SyncCookieStorage` scoped to the domain you own, written without any subdomain: `example.com`. |
 
-`domain` must be your own domain or one above the current host, and cannot be a public suffix like `com`. Nothing needs to be served there. Assume one shared session per domain: a second one alongside it would overwrite the first's state, so give a staging deployment its own domain or leave `syncStorage` unset on it.
+Set `domain` to a domain you own outright and that hosts nothing but your own applications. Never a domain shared with others, such as a hosting or gateway domain — every application under it would read and write the same cookie. Nothing needs to be served at the domain itself.
+
+Use one shared session per domain. A second one under `example.com` would overwrite this one's state, so give a staging deployment its own domain.
 
 Everything else is unchanged. `signIn()` and `signOut()` work as usual, and signing out on one origin ends the session on all of them.
 
 ## Checking for a session
 
-`isAuthenticated()` is synchronous, so it reads a small cookie rather than the shared session itself. Treat it as a hint for deciding what to render — any script on your domain can change it. Use the identity when it matters:
+`isAuthenticated()` is synchronous, so it answers from the cookie rather than the shared session. With `syncStorage` set it is correct on every origin from the first load; leave it unset and it returns `false` on an origin's first load until the session has been read once.
+
+To act on the identity itself:
 
 ```typescript
 const identity = await authClient.getIdentity();
@@ -84,10 +84,8 @@ if (identity.getPrincipal().isAnonymous()) {
 }
 ```
 
-Without `syncStorage`, `isAuthenticated()` returns `false` on an origin's first load until the session has been read once.
-
 ## Good to know
 
-- Sharing works between origins on one domain. A different domain reads an empty session, even if it is listed in the record.
+- Sharing works between origins on one domain. An origin on a different domain reads an empty session, even if it is listed in the record.
 - Safari clears browser storage after seven days without a visit, and private windows keep it only for the tab. Both look like no session, which `signIn()` recovers from.
 - Pick the derivation origin before launch. Every principal derives from it, so changing it later gives every user a new identity with no way back to the old one.

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -60,7 +60,7 @@ import { SharedSessionStorage } from '@icp-sdk/auth/shared-session';
 const DERIVATION_ORIGIN = 'https://example.com';
 
 const sharedSession = new SharedSessionStorage({
-  hub: { url: 'https://example.com/shared-session.html' },
+  url: 'https://example.com/shared-session.html',
   derivationOrigin: DERIVATION_ORIGIN,
 });
 
@@ -89,7 +89,7 @@ const authClient = new AuthClient({
   storage: sharedSession,
   syncStorage: new SyncCookieStorage({
     domain: 'example.com',
-    namespace: sharedSession.hubOrigin,
+    derivationOrigin: DERIVATION_ORIGIN,
   }),
   derivationOrigin: DERIVATION_ORIGIN,
 });
@@ -97,7 +97,7 @@ const authClient = new AuthClient({
 
 `domain` is what the sharing origins have in common, and must be the current host or a domain above it — a browser rejects anything else, including a sibling subdomain, and refuses a public suffix outright. Nothing needs to be served at it: a hub on `auth.example.com` can scope its cookie to `example.com` even if nothing answers there.
 
-`namespace` keeps two shared sessions under one domain from describing each other's state, which matters for a staging deployment beside production. `hubOrigin` identifies the session, since the hub is where it lives.
+`derivationOrigin` becomes part of the cookie's name, so two shared sessions under one domain — a staging deployment beside production — do not write the same cookie and describe each other's state. It is the same constant the other two options take.
 
 The cookie holds one non-secret value, a timestamp, and its `Max-Age` comes from the delegation, so it cannot outlive the session it describes. Signing out on any origin deletes it for all of them.
 

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -3,7 +3,7 @@ title: Shared Session
 description: Share one principal and one sign-in across several apps on your domain.
 ---
 
-Use a shared session when several apps under one custom domain need the same principal and the same sign-in state — `docs.example.com` and `chat.example.com` signing in once, as the same user.
+Use a shared session when several apps under one custom domain need the same principal and the same sign-in state, so that `docs.example.com` and `chat.example.com` sign in once as the same user.
 
 A `derivationOrigin` alone gives them the same principal, but each app still signs in separately and keeps its own session. The setup below shares the session itself, so signing in or out of one app applies to all of them.
 
@@ -34,13 +34,11 @@ Content-Security-Policy: frame-ancestors 'self' https://docs.example.com https:/
 
 ## 2. Authorize each app
 
-The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record — `https://auth.example.com/.well-known/ii-alternative-origins` here — served with `Access-Control-Allow-Origin: *`:
+The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record, served with `Access-Control-Allow-Origin: *`. Here that is `https://auth.example.com/.well-known/ii-alternative-origins`:
 
 ```json
 { "alternativeOrigins": ["https://docs.example.com", "https://chat.example.com"] }
 ```
-
-Internet Identity allows at most 10 entries.
 
 ## 3. Point each app at it
 

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -7,7 +7,7 @@ Use a shared session when several apps under one custom domain need the same pri
 
 A `derivationOrigin` alone gives them the same principal, but each app still signs in separately and keeps its own session. The setup below shares the session itself, so signing in or out of one app applies to all of them.
 
-Throughout, `example.com` is that custom domain and `https://auth.example.com` is the derivation origin: the origin the shared principal is derived for. It must resolve to a canister.
+A shared session requires a derivation origin. The examples below use `example.com` as the custom domain and `https://auth.example.com` as the derivation origin.
 
 ## 1. Host the session
 
@@ -24,12 +24,6 @@ Deploy a page that calls `serveSharedSession`, on any origin you control:
 import { serveSharedSession } from '@icp-sdk/auth/shared-session';
 
 serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
-```
-
-Serve it with a header naming the origins allowed to embed it:
-
-```
-Content-Security-Policy: frame-ancestors 'self' https://docs.example.com https://chat.example.com;
 ```
 
 ## 2. Authorize each app

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -28,7 +28,7 @@ serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 
 ## 2. Authorize each app
 
-The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record, served with `Access-Control-Allow-Origin: *`. Here that is `https://auth.example.com/.well-known/ii-alternative-origins`:
+The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record:
 
 ```json
 { "alternativeOrigins": ["https://docs.example.com", "https://chat.example.com"] }

--- a/docs/src/content/docs/shared-session.md
+++ b/docs/src/content/docs/shared-session.md
@@ -1,17 +1,17 @@
 ---
 title: Shared Session
-description: Share one sign-in across several origins of the same application.
+description: Share one principal and one sign-in across several apps on your domain.
 ---
 
-By default a session belongs to the origin it was created on, so an application served from `docs.example.com` and `chat.example.com` asks the user to sign in twice and gives each origin a different principal.
+Use a shared session when several apps under one custom domain need the same principal and the same sign-in state — `docs.example.com` and `chat.example.com` signing in once, as the same user.
 
-A shared session fixes both. One origin hosts the session, the others read it from there, and a `derivationOrigin` keeps the principal the same everywhere.
+A `derivationOrigin` alone gives them the same principal, but each app still signs in separately and keeps its own session. The setup below shares the session itself, so signing in or out of one app applies to all of them.
 
-You need three things: a page that hosts the session, an entry per origin in an Internet Identity record, and a few options on each client.
+Throughout, `example.com` is that custom domain and `https://auth.example.com` is the derivation origin: the origin the shared principal is derived for. It must resolve to a canister.
 
 ## 1. Host the session
 
-Deploy a page that calls `serveSharedSession`. It needs no markup and no interaction, and can live on any origin you control — for an app on `docs.example.com` and `chat.example.com`, a dedicated `https://auth.example.com/shared-session.html` keeps it away from your application code.
+Deploy a page that calls `serveSharedSession`, on any origin you control:
 
 ```html
 <!doctype html>
@@ -26,25 +26,23 @@ import { serveSharedSession } from '@icp-sdk/auth/shared-session';
 serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
 ```
 
-Set `derivationOrigin` to the origin whose principal your users get — the same value every client signs in with. It must resolve to a canister, which Internet Identity requires of a derivation origin.
-
-Serve the page with a header naming the origins allowed to embed it:
+Serve it with a header naming the origins allowed to embed it:
 
 ```
 Content-Security-Policy: frame-ancestors 'self' https://docs.example.com https://chat.example.com;
 ```
 
-## 2. Authorize each origin
+## 2. Authorize each app
 
-Add every consuming origin to `https://auth.example.com/.well-known/ii-alternative-origins`, served with `Access-Control-Allow-Origin: *`:
+The derivation origin decides which origins may read the session. List them in its [`.well-known/ii-alternative-origins`](https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc#alternative-frontend-origins) record — `https://auth.example.com/.well-known/ii-alternative-origins` here — served with `Access-Control-Allow-Origin: *`:
 
 ```json
 { "alternativeOrigins": ["https://docs.example.com", "https://chat.example.com"] }
 ```
 
-This record is the only thing that decides who may read the session, so treat adding an entry as a security change and keep it to origins you deploy yourself. Internet Identity allows at most 10.
+Internet Identity allows at most 10 entries.
 
-## 3. Point each client at it
+## 3. Point each app at it
 
 On `docs.example.com` and `chat.example.com` alike:
 
@@ -62,30 +60,5 @@ const authClient = new AuthClient({
 | Option | Set it to |
 | --- | --- |
 | `storage` | A `SharedSessionStorage` pointing at the page from step 1. |
-| `derivationOrigin` | The origin that page is served from. A different value silently stores a session no other origin can use. |
-| `syncStorage` | A `SyncCookieStorage` scoped to the domain you own, written without any subdomain: `example.com`. |
-
-Set `domain` to a domain you own outright and that hosts nothing but your own applications. Never a domain shared with others, such as a hosting or gateway domain — every application under it would read and write the same cookie. Nothing needs to be served at the domain itself.
-
-Use one shared session per domain. A second one under `example.com` would overwrite this one's state, so give a staging deployment its own domain.
-
-Everything else is unchanged. `signIn()` and `signOut()` work as usual, and signing out on one origin ends the session on all of them.
-
-## Checking for a session
-
-`isAuthenticated()` is synchronous, so it answers from the cookie rather than the shared session. With `syncStorage` set it is correct on every origin from the first load; leave it unset and it returns `false` on an origin's first load until the session has been read once.
-
-To act on the identity itself:
-
-```typescript
-const identity = await authClient.getIdentity();
-if (identity.getPrincipal().isAnonymous()) {
-  await authClient.signIn();
-}
-```
-
-## Good to know
-
-- Sharing works between origins on one domain. An origin on a different domain reads an empty session, even if it is listed in the record.
-- Safari clears browser storage after seven days without a visit, and private windows keep it only for the tab. Both look like no session, which `signIn()` recovers from.
-- Pick the derivation origin before launch. Every principal derives from it, so changing it later gives every user a new identity with no way back to the old one.
+| `syncStorage` | A `SyncCookieStorage` scoped to your custom domain. |
+| `derivationOrigin` | The origin to derive the principal for. |

--- a/docs/typedoc.json
+++ b/docs/typedoc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://typedoc-plugin-markdown.org/schema.json",
-  "entryPoints": ["../src/client/index.ts"],
+  "entryPoints": ["../src/client/index.ts", "../src/shared-session/index.ts"],
   "tsconfig": "../tsconfig.lib.json",
   "readme": "none",
   "out": "src/content/tmp",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/esm/client/index.js",
       "default": "./dist/esm/client/index.js"
     },
+    "./shared-session": {
+      "types": "./dist/esm/shared-session/index.d.ts",
+      "import": "./dist/esm/shared-session/index.js",
+      "default": "./dist/esm/shared-session/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -627,7 +627,7 @@ export class AuthClient {
       // and leave every getIdentity() rejecting for the page's lifetime.
       // Staying anonymous is recoverable: a signIn() still works.
       //
-      // The cached expiration is deliberately left alone — a hub that failed to
+      // The cached expiration is deliberately left alone: a hub that failed to
       // answer has not told us the session is gone, and clearing it would sign
       // the user out of this origin on a transient error.
       console.error(`Failed to restore the session: ${String(error)}`);

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -11,6 +11,7 @@ import {
 import type { Principal } from '@icp-sdk/core/principal';
 import { Signer } from '@icp-sdk/signer';
 import { PostMessageTransport, UrlTransport } from '@icp-sdk/signer/web';
+import { type SharedSessionHubOptions, SharedSessionStorage } from '../shared-session/storage.js';
 import { IdleManager, type IdleManagerOptions } from './idle-manager.js';
 import {
   type AuthClientStorage,
@@ -66,19 +67,14 @@ export const OPENID_PROVIDER_URLS = {
 const DEFAULT_OPENID_SCOPE_KEYS = ['name', 'email', 'verified_email'] as const;
 
 /**
- * Options for creating an {@link AuthClient}.
+ * Options for creating an {@link AuthClient}, other than those constrained by
+ * {@link AuthClientCreateOptions}.
  */
-export interface AuthClientCreateOptions {
+export interface AuthClientCreateBaseOptions {
   /**
    * An identity to authenticate via delegation.
    */
   identity?: SignIdentity | PartialIdentity;
-
-  /**
-   * Persistent storage backend. Defaults to IndexedDB.
-   * @default IdbStorage
-   */
-  storage?: AuthClientStorage;
 
   /**
    * Type of session key to generate on each sign-in.
@@ -99,12 +95,6 @@ export interface AuthClientCreateOptions {
    * @default "https://id.ai/authorize"
    */
   identityProvider?: string | URL;
-
-  /**
-   * Derivation origin for the identity provider.
-   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
-   */
-  derivationOrigin?: string | URL;
 
   /**
    * Window features string for the authentication popup.
@@ -143,6 +133,66 @@ export interface AuthClientCreateOptions {
    */
   openIdProvider?: OpenIdProvider;
 }
+
+/**
+ * Options for creating an {@link AuthClient}.
+ *
+ * `sharedSessionHub` requires `derivationOrigin` and excludes `storage`. Sharing
+ * a session without a shared derivation origin would give each origin a
+ * different principal from the same key — a shared store holding an identity
+ * nobody else can use — so the two belong together, and the hub replaces the
+ * local store rather than sitting alongside it.
+ */
+export type AuthClientCreateOptions = AuthClientCreateBaseOptions &
+  (
+    | {
+        /**
+         * Serves the session from another origin, so every origin authorized by
+         * the derivation origin shares one sign-in.
+         *
+         * Point it at a page that calls `serveSharedSession` from
+         * `@icp-sdk/auth/shared-session`. That page's origin holds the session;
+         * this origin stores nothing. Which origins may read it is decided by the
+         * derivation origin's `/.well-known/ii-alternative-origins` record, the
+         * same record Internet Identity checks when deriving the principal.
+         *
+         * @see {@link SharedSessionStorage}
+         * @example
+         * ```ts
+         * new AuthClient({
+         *   sharedSessionHub: { url: 'https://auth.example.com/hub.html' },
+         *   derivationOrigin: 'https://auth.example.com',
+         * });
+         * ```
+         */
+        sharedSessionHub: SharedSessionHubOptions;
+
+        /**
+         * Derivation origin for the identity provider. Required alongside
+         * `sharedSessionHub`, and must match the hub's own configuration.
+         * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+         */
+        derivationOrigin: string | URL;
+
+        /** Not available with `sharedSessionHub`, which supplies the store. */
+        storage?: never;
+      }
+    | {
+        sharedSessionHub?: undefined;
+
+        /**
+         * Derivation origin for the identity provider.
+         * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+         */
+        derivationOrigin?: string | URL;
+
+        /**
+         * Persistent storage backend. Defaults to IndexedDB.
+         * @default IdbStorage
+         */
+        storage?: AuthClientStorage;
+      }
+  );
 
 export interface IdleOptions extends IdleManagerOptions {
   /**
@@ -203,7 +253,7 @@ export class AuthClient {
 
   constructor(options: AuthClientCreateOptions = {}) {
     this.#options = options;
-    this.#storage = options.storage ?? new IdbStorage();
+    this.#storage = createStorage(options);
 
     const identityProviderUrl = new URL(
       options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
@@ -594,17 +644,48 @@ export class AuthClient {
     return this.#initPromise;
   }
 
+  // Runs #restore, absorbing a failure so the client stays usable.
+  async #hydrate(): Promise<void> {
+    try {
+      await this.#restore();
+    } catch (error) {
+      // A store on another origin can be unreachable, which IndexedDB
+      // effectively never was. The constructor starts hydration without
+      // awaiting it, so rejecting here would surface as an unhandled rejection
+      // and leave every getIdentity() rejecting for the page's lifetime.
+      // Staying anonymous is recoverable: a signIn() still works.
+      //
+      // The cached expiration is deliberately left alone — a hub that failed to
+      // answer has not told us the session is gone, and clearing it would sign
+      // the user out of this origin on a transient error.
+      console.error(`Failed to restore the session: ${String(error)}`);
+    }
+  }
+
   // Attempts to restore a previous session (key + delegation chain) from
   // storage. If found and still valid, sets #identity and #chain so the
   // client is ready to use without a new signIn().
-  async #hydrate(): Promise<void> {
+  async #restore(): Promise<void> {
     const key =
       this.#options.identity ??
       (await restoreKey(this.#storage, this.#options.keyType ?? ECDSA_KEY_LABEL));
-    if (!key) return;
+    if (!key) {
+      clearCachedExpiration();
+      return;
+    }
 
     const chain = await restoreChain(this.#storage);
-    if (!chain) return;
+    if (!chain) {
+      // A shared session can be signed out from another origin, which cannot
+      // reach this origin's cached expiration. Clearing it here stops
+      // isAuthenticated() reporting a session that is no longer in the store.
+      clearCachedExpiration();
+      return;
+    }
+
+    // This origin may be restoring a session it never signed in for, in which
+    // case it has no cached expiration of its own yet.
+    cacheExpiration(chain);
 
     this.#chain = chain;
     if ('toDer' in key) {
@@ -632,6 +713,30 @@ export class AuthClient {
       });
     }
   }
+}
+
+/**
+ * Resolves the storage backend for a set of create options.
+ *
+ * `sharedSessionHub` wins over `storage` at runtime. The types make the two
+ * mutually exclusive, so reaching the warning means the call came from
+ * JavaScript, where silently reading a store the session was never written to
+ * would look like the user is signed out.
+ * @param options - The create options.
+ */
+function createStorage(options: AuthClientCreateOptions): AuthClientStorage {
+  if (options.sharedSessionHub === undefined) {
+    return options.storage ?? new IdbStorage();
+  }
+  if (options.storage !== undefined) {
+    console.warn(
+      '`storage` is ignored when `sharedSessionHub` is set: the shared session is held by the hub.',
+    );
+  }
+  return new SharedSessionStorage({
+    hub: options.sharedSessionHub,
+    derivationOrigin: options.derivationOrigin,
+  });
 }
 
 /**
@@ -826,7 +931,19 @@ function serializeKey(key: SignIdentity | PartialIdentity): StoredKey {
  */
 async function persistChain(storage: AuthClientStorage, chain: DelegationChain): Promise<void> {
   await storage.set(KEY_STORAGE_DELEGATION, JSON.stringify(chain.toJSON()));
+  cacheExpiration(chain);
+}
 
+/**
+ * Caches a chain's earliest expiration in localStorage, so
+ * {@link AuthClient.isAuthenticated} can answer synchronously.
+ *
+ * The cache is per-origin while a shared session is not, so it is written on
+ * restore as well as on sign-in: an origin that shares a session never signed in
+ * itself and would otherwise report no session at all.
+ * @param chain - The delegation chain being made current.
+ */
+function cacheExpiration(chain: DelegationChain): void {
   let earliest: bigint | null = null;
   for (const { delegation } of chain.delegations) {
     if (earliest === null || delegation.expiration < earliest) {
@@ -869,6 +986,11 @@ async function deleteStorage(storage: AuthClientStorage): Promise<void> {
   await storage.remove(KEY_STORAGE_KEY);
   await storage.remove(KEY_STORAGE_DELEGATION);
   await storage.remove(KEY_VECTOR);
+  clearCachedExpiration();
+}
+
+/** Drops the cached expiration, so {@link AuthClient.isAuthenticated} reports no session. */
+function clearCachedExpiration(): void {
   localStorage.removeItem(KEY_STORAGE_EXPIRATION);
 }
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -90,7 +90,7 @@ export interface AuthClientCreateOptions {
 
   /**
    * Derivation origin for the identity provider.
-   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   * @see https://docs.internetcomputer.org/references/internet-identity-spec/#alternative-frontend-origins
    */
   derivationOrigin?: string | URL;
 

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -641,19 +641,15 @@ export class AuthClient {
     const key =
       this.#options.identity ??
       (await restoreKey(this.#storage, this.#options.keyType ?? ECDSA_KEY_LABEL));
-    if (!key) {
-      clearCachedExpiration(this.#syncStorage);
-      return;
-    }
+    if (!key) return;
 
     const chain = await restoreChain(this.#storage, this.#syncStorage);
-    if (!chain) {
-      // A shared session can be signed out from another origin, which cannot
-      // reach this origin's cached expiration. Clearing it here stops
-      // isAuthenticated() reporting a session that is no longer in the store.
-      clearCachedExpiration(this.#syncStorage);
-      return;
-    }
+    // An empty store is deliberately not treated as a reason to clear the
+    // cached expiration. With a shared session that cache is shared too, so one
+    // origin that cannot see the session would delete the others' hint. The
+    // cache carries the delegation's own expiry, so it lapses on its own;
+    // signing out and an expired chain both clear it through deleteStorage.
+    if (!chain) return;
 
     // This origin may be restoring a session it never signed in for, in which
     // case it has no cached expiration of its own yet.

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -778,11 +778,15 @@ function createSyncStorage(options: AuthClientCreateOptions): AuthClientSyncStor
   if (options.sharedSessionHub === undefined) {
     return new SyncLocalStorage();
   }
-  // A cookie can only be scoped to this host or a domain above it, so a
-  // derivation origin that is a sibling (auth.example.com next to
-  // a.example.com) cannot be written to and would leave every read empty.
-  // Falling back keeps this origin correct once it has read the shared store.
-  const domain = new URL(options.derivationOrigin.toString()).hostname;
+  // Scoped to the hub, not the derivation origin: the hub has to be same-site
+  // with the origins it serves, or its storage is partitioned and there is
+  // nothing to share, while the derivation origin may be an unrelated domain.
+  //
+  // A cookie can only be scoped to this host or a domain above it, so a hub
+  // that is a sibling (auth.example.com next to a.example.com) cannot be
+  // written to and would leave every read empty. Falling back keeps this origin
+  // correct once it has read the shared store.
+  const domain = new URL(options.sharedSessionHub.url.toString()).hostname;
   // Falls back rather than throwing where the host is unavailable, so a
   // constructor never fails over a synchronous hint.
   const hostname = globalThis.location?.hostname ?? '';

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -11,7 +11,6 @@ import {
 import type { Principal } from '@icp-sdk/core/principal';
 import { Signer } from '@icp-sdk/signer';
 import { PostMessageTransport, UrlTransport } from '@icp-sdk/signer/web';
-import { type SharedSessionHubOptions, SharedSessionStorage } from '../shared-session/storage.js';
 import { IdleManager, type IdleManagerOptions } from './idle-manager.js';
 import {
   type AuthClientStorage,
@@ -22,7 +21,7 @@ import {
   LocalStorage,
   type StoredKey,
 } from './storage.js';
-import { type AuthClientSyncStorage, SyncCookieStorage, SyncLocalStorage } from './sync-storage.js';
+import { type AuthClientSyncStorage, SyncLocalStorage } from './sync-storage.js';
 
 const NANOSECONDS_PER_MILLISECOND = BigInt(1_000_000);
 const NANOSECONDS_PER_SECOND = BigInt(1_000_000_000);
@@ -38,7 +37,7 @@ type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
 // Key the delegation expiration is cached under, so isAuthenticated() can
 // answer synchronously without reading the session store. See
-// AuthClientCreateBaseOptions#syncStorage for where it is kept.
+// AuthClientCreateOptions#syncStorage for where it is kept.
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
 // Storage key prefix for a redirect flow's session key, held only while the
@@ -70,14 +69,30 @@ export const OPENID_PROVIDER_URLS = {
 const DEFAULT_OPENID_SCOPE_KEYS = ['name', 'email', 'verified_email'] as const;
 
 /**
- * Options for creating an {@link AuthClient}, other than those constrained by
- * {@link AuthClientCreateOptions}.
+ * Options for creating an {@link AuthClient}.
  */
-export interface AuthClientCreateBaseOptions {
+export interface AuthClientCreateOptions {
   /**
    * An identity to authenticate via delegation.
    */
   identity?: SignIdentity | PartialIdentity;
+
+  /**
+   * Persistent storage backend. Defaults to IndexedDB.
+   *
+   * Set it to a `SharedSessionStorage` from `@icp-sdk/auth/shared-session`
+   * to share one sign-in across several origins of the same application. Pass
+   * the same `derivationOrigin` there as here, or the session would be stored
+   * for a principal other than the one this client signs in as.
+   * @default IdbStorage
+   */
+  storage?: AuthClientStorage;
+
+  /**
+   * Derivation origin for the identity provider.
+   * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
+   */
+  derivationOrigin?: string | URL;
 
   /**
    * Type of session key to generate on each sign-in.
@@ -97,9 +112,10 @@ export interface AuthClientCreateBaseOptions {
    * Synchronous storage for the delegation expiration that
    * {@link AuthClient.isAuthenticated} reads.
    *
-   * Defaults to `localStorage`, or to a cookie scoped to the derivation
-   * origin's domain when `sharedSessionHub` is set, so that an origin sharing a
-   * session can answer before it has read the shared store.
+   * Defaults to `localStorage`, which is scoped to one origin. With a shared
+   * session, set it to a `SyncCookieStorage` scoped to the domain the
+   * sharing origins have in common, so each of them can answer before it has
+   * read the shared store.
    * @default SyncLocalStorage
    */
   syncStorage?: AuthClientSyncStorage;
@@ -147,66 +163,6 @@ export interface AuthClientCreateBaseOptions {
    */
   openIdProvider?: OpenIdProvider;
 }
-
-/**
- * Options for creating an {@link AuthClient}.
- *
- * `sharedSessionHub` requires `derivationOrigin` and excludes `storage`. Sharing
- * a session without a shared derivation origin would give each origin a
- * different principal from the same key — a shared store holding an identity
- * nobody else can use — so the two belong together, and the hub replaces the
- * local store rather than sitting alongside it.
- */
-export type AuthClientCreateOptions = AuthClientCreateBaseOptions &
-  (
-    | {
-        /**
-         * Serves the session from another origin, so every origin authorized by
-         * the derivation origin shares one sign-in.
-         *
-         * Point it at a page that calls `serveSharedSession` from
-         * `@icp-sdk/auth/shared-session`. That page's origin holds the session;
-         * this origin stores nothing. Which origins may read it is decided by the
-         * derivation origin's `/.well-known/ii-alternative-origins` record, the
-         * same record Internet Identity checks when deriving the principal.
-         *
-         * @see {@link SharedSessionStorage}
-         * @example
-         * ```ts
-         * new AuthClient({
-         *   sharedSessionHub: { url: 'https://auth.example.com/hub.html' },
-         *   derivationOrigin: 'https://auth.example.com',
-         * });
-         * ```
-         */
-        sharedSessionHub: SharedSessionHubOptions;
-
-        /**
-         * Derivation origin for the identity provider. Required alongside
-         * `sharedSessionHub`, and must match the hub's own configuration.
-         * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
-         */
-        derivationOrigin: string | URL;
-
-        /** Not available with `sharedSessionHub`, which supplies the store. */
-        storage?: never;
-      }
-    | {
-        sharedSessionHub?: undefined;
-
-        /**
-         * Derivation origin for the identity provider.
-         * @see https://github.com/dfinity/internet-identity/blob/main/docs/internet-identity-spec.adoc
-         */
-        derivationOrigin?: string | URL;
-
-        /**
-         * Persistent storage backend. Defaults to IndexedDB.
-         * @default IdbStorage
-         */
-        storage?: AuthClientStorage;
-      }
-  );
 
 export interface IdleOptions extends IdleManagerOptions {
   /**
@@ -268,8 +224,8 @@ export class AuthClient {
 
   constructor(options: AuthClientCreateOptions = {}) {
     this.#options = options;
-    this.#storage = createStorage(options);
-    this.#syncStorage = createSyncStorage(options);
+    this.#storage = options.storage ?? new IdbStorage();
+    this.#syncStorage = options.syncStorage ?? new SyncLocalStorage();
 
     const identityProviderUrl = new URL(
       options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
@@ -729,71 +685,6 @@ export class AuthClient {
       });
     }
   }
-}
-
-/**
- * Resolves the storage backend for a set of create options.
- *
- * `sharedSessionHub` wins over `storage` at runtime. The types make the two
- * mutually exclusive, so reaching the warning means the call came from
- * JavaScript, where silently reading a store the session was never written to
- * would look like the user is signed out.
- * @param options - The create options.
- */
-function createStorage(options: AuthClientCreateOptions): AuthClientStorage {
-  if (options.sharedSessionHub === undefined) {
-    return options.storage ?? new IdbStorage();
-  }
-  if (options.storage !== undefined) {
-    console.warn(
-      '`storage` is ignored when `sharedSessionHub` is set: the shared session is held by the hub.',
-    );
-  }
-  return new SharedSessionStorage({
-    hub: options.sharedSessionHub,
-    derivationOrigin: options.derivationOrigin,
-  });
-}
-
-/**
- * Resolves the synchronous storage for the expiration that
- * {@link AuthClient.isAuthenticated} reads.
- *
- * With a shared session the expiration has to be readable by every origin that
- * shares it, and synchronously, which rules out both `localStorage` (scoped to
- * one origin) and the shared store itself (asynchronous, and on another origin).
- * A cookie scoped to the derivation origin's domain is the remaining option.
- *
- * It holds nothing secret — a timestamp the reader compares against the current
- * time — and the identity it describes is still fetched and verified from the
- * store, so a cookie written by another subdomain can make
- * {@link AuthClient.isAuthenticated} briefly wrong but cannot authenticate
- * anyone.
- * @param options - The create options.
- */
-function createSyncStorage(options: AuthClientCreateOptions): AuthClientSyncStorage {
-  if (options.syncStorage !== undefined) {
-    return options.syncStorage;
-  }
-  if (options.sharedSessionHub === undefined) {
-    return new SyncLocalStorage();
-  }
-  // Scoped to the hub, not the derivation origin: the hub has to be same-site
-  // with the origins it serves, or its storage is partitioned and there is
-  // nothing to share, while the derivation origin may be an unrelated domain.
-  //
-  // A cookie can only be scoped to this host or a domain above it, so a hub
-  // that is a sibling (auth.example.com next to a.example.com) cannot be
-  // written to and would leave every read empty. Falling back keeps this origin
-  // correct once it has read the shared store.
-  const domain = new URL(options.sharedSessionHub.url.toString()).hostname;
-  // Falls back rather than throwing where the host is unavailable, so a
-  // constructor never fails over a synchronous hint.
-  const hostname = globalThis.location?.hostname ?? '';
-  if (hostname !== domain && !hostname.endsWith(`.${domain}`)) {
-    return new SyncLocalStorage();
-  }
-  return new SyncCookieStorage({ domain });
 }
 
 /**

--- a/src/client/auth-client.ts
+++ b/src/client/auth-client.ts
@@ -22,7 +22,9 @@ import {
   LocalStorage,
   type StoredKey,
 } from './storage.js';
+import { type AuthClientSyncStorage, SyncCookieStorage, SyncLocalStorage } from './sync-storage.js';
 
+const NANOSECONDS_PER_MILLISECOND = BigInt(1_000_000);
 const NANOSECONDS_PER_SECOND = BigInt(1_000_000_000);
 const SECONDS_PER_HOUR = BigInt(3_600);
 const NANOSECONDS_PER_HOUR = NANOSECONDS_PER_SECOND * SECONDS_PER_HOUR;
@@ -34,8 +36,9 @@ const ECDSA_KEY_LABEL = 'ECDSA';
 const ED25519_KEY_LABEL = 'Ed25519';
 type BaseKeyType = typeof ECDSA_KEY_LABEL | typeof ED25519_KEY_LABEL;
 
-// localStorage key used to cache the delegation expiration so that
-// isAuthenticated() can answer synchronously without hitting IndexedDB.
+// Key the delegation expiration is cached under, so isAuthenticated() can
+// answer synchronously without reading the session store. See
+// AuthClientCreateBaseOptions#syncStorage for where it is kept.
 const KEY_STORAGE_EXPIRATION = 'ic-delegation_expiration';
 
 // Storage key prefix for a redirect flow's session key, held only while the
@@ -89,6 +92,17 @@ export interface AuthClientCreateBaseOptions {
    * @default after 10 minutes, invalidates the identity
    */
   idleOptions?: IdleOptions;
+
+  /**
+   * Synchronous storage for the delegation expiration that
+   * {@link AuthClient.isAuthenticated} reads.
+   *
+   * Defaults to `localStorage`, or to a cookie scoped to the derivation
+   * origin's domain when `sharedSessionHub` is set, so that an origin sharing a
+   * session can answer before it has read the shared store.
+   * @default SyncLocalStorage
+   */
+  syncStorage?: AuthClientSyncStorage;
 
   /**
    * Identity provider URL.
@@ -243,6 +257,7 @@ export class AuthClient {
   #identity: Identity | PartialIdentity = new AnonymousIdentity();
   #chain: DelegationChain | null = null;
   #storage: AuthClientStorage;
+  #syncStorage: AuthClientSyncStorage;
   #signer: Signer;
   // Set only in redirect mode, so the redirect-specific paths (nonce/key
   // journaling) can reach `memoize`. Undefined in the default 'window' mode.
@@ -254,6 +269,7 @@ export class AuthClient {
   constructor(options: AuthClientCreateOptions = {}) {
     this.#options = options;
     this.#storage = createStorage(options);
+    this.#syncStorage = createSyncStorage(options);
 
     const identityProviderUrl = new URL(
       options.identityProvider?.toString() || IDENTITY_PROVIDER_DEFAULT,
@@ -309,7 +325,7 @@ export class AuthClient {
    */
   isAuthenticated(): boolean {
     // Uses a cached expiration in localStorage to avoid an async IndexedDB read.
-    const expiration = getExpirationFlag();
+    const expiration = getExpirationFlag(this.#syncStorage);
     if (expiration === null) return false;
     const nowNs = BigInt(Date.now()) * BigInt(1_000_000);
     return nowNs < expiration;
@@ -389,7 +405,7 @@ export class AuthClient {
     }
 
     // Persist so the session survives page reloads.
-    await persistChain(this.#storage, this.#chain);
+    await persistChain(this.#storage, this.#syncStorage, this.#chain);
     await persistKey(this.#storage, key);
 
     // The flow is complete: the delegation is bound to this key and stored, so
@@ -587,7 +603,7 @@ export class AuthClient {
     // Wait for the constructor's session restore: hydration racing the
     // deletion below could re-populate the identity from already-read state.
     await this.#init();
-    await deleteStorage(this.#storage);
+    await deleteStorage(this.#storage, this.#syncStorage);
 
     this.#identity = new AnonymousIdentity();
     this.#chain = null;
@@ -670,22 +686,22 @@ export class AuthClient {
       this.#options.identity ??
       (await restoreKey(this.#storage, this.#options.keyType ?? ECDSA_KEY_LABEL));
     if (!key) {
-      clearCachedExpiration();
+      clearCachedExpiration(this.#syncStorage);
       return;
     }
 
-    const chain = await restoreChain(this.#storage);
+    const chain = await restoreChain(this.#storage, this.#syncStorage);
     if (!chain) {
       // A shared session can be signed out from another origin, which cannot
       // reach this origin's cached expiration. Clearing it here stops
       // isAuthenticated() reporting a session that is no longer in the store.
-      clearCachedExpiration();
+      clearCachedExpiration(this.#syncStorage);
       return;
     }
 
     // This origin may be restoring a session it never signed in for, in which
     // case it has no cached expiration of its own yet.
-    cacheExpiration(chain);
+    cacheExpiration(this.#syncStorage, chain);
 
     this.#chain = chain;
     if ('toDer' in key) {
@@ -737,6 +753,43 @@ function createStorage(options: AuthClientCreateOptions): AuthClientStorage {
     hub: options.sharedSessionHub,
     derivationOrigin: options.derivationOrigin,
   });
+}
+
+/**
+ * Resolves the synchronous storage for the expiration that
+ * {@link AuthClient.isAuthenticated} reads.
+ *
+ * With a shared session the expiration has to be readable by every origin that
+ * shares it, and synchronously, which rules out both `localStorage` (scoped to
+ * one origin) and the shared store itself (asynchronous, and on another origin).
+ * A cookie scoped to the derivation origin's domain is the remaining option.
+ *
+ * It holds nothing secret — a timestamp the reader compares against the current
+ * time — and the identity it describes is still fetched and verified from the
+ * store, so a cookie written by another subdomain can make
+ * {@link AuthClient.isAuthenticated} briefly wrong but cannot authenticate
+ * anyone.
+ * @param options - The create options.
+ */
+function createSyncStorage(options: AuthClientCreateOptions): AuthClientSyncStorage {
+  if (options.syncStorage !== undefined) {
+    return options.syncStorage;
+  }
+  if (options.sharedSessionHub === undefined) {
+    return new SyncLocalStorage();
+  }
+  // A cookie can only be scoped to this host or a domain above it, so a
+  // derivation origin that is a sibling (auth.example.com next to
+  // a.example.com) cannot be written to and would leave every read empty.
+  // Falling back keeps this origin correct once it has read the shared store.
+  const domain = new URL(options.derivationOrigin.toString()).hostname;
+  // Falls back rather than throwing where the host is unavailable, so a
+  // constructor never fails over a synchronous hint.
+  const hostname = globalThis.location?.hostname ?? '';
+  if (hostname !== domain && !hostname.endsWith(`.${domain}`)) {
+    return new SyncLocalStorage();
+  }
+  return new SyncCookieStorage({ domain });
 }
 
 /**
@@ -929,9 +982,13 @@ function serializeKey(key: SignIdentity | PartialIdentity): StoredKey {
  * @param storage - The storage backend.
  * @param chain - The delegation chain to persist.
  */
-async function persistChain(storage: AuthClientStorage, chain: DelegationChain): Promise<void> {
+async function persistChain(
+  storage: AuthClientStorage,
+  syncStorage: AuthClientSyncStorage,
+  chain: DelegationChain,
+): Promise<void> {
   await storage.set(KEY_STORAGE_DELEGATION, JSON.stringify(chain.toJSON()));
-  cacheExpiration(chain);
+  cacheExpiration(syncStorage, chain);
 }
 
 /**
@@ -943,7 +1000,7 @@ async function persistChain(storage: AuthClientStorage, chain: DelegationChain):
  * itself and would otherwise report no session at all.
  * @param chain - The delegation chain being made current.
  */
-function cacheExpiration(chain: DelegationChain): void {
+function cacheExpiration(syncStorage: AuthClientSyncStorage, chain: DelegationChain): void {
   let earliest: bigint | null = null;
   for (const { delegation } of chain.delegations) {
     if (earliest === null || delegation.expiration < earliest) {
@@ -951,7 +1008,11 @@ function cacheExpiration(chain: DelegationChain): void {
     }
   }
   if (earliest !== null) {
-    localStorage.setItem(KEY_STORAGE_EXPIRATION, earliest.toString());
+    syncStorage.set(
+      KEY_STORAGE_EXPIRATION,
+      earliest.toString(),
+      Number(earliest / NANOSECONDS_PER_MILLISECOND),
+    );
   }
 }
 
@@ -960,20 +1021,23 @@ function cacheExpiration(chain: DelegationChain): void {
  * storage if the chain is expired or corrupted.
  * @param storage - The storage backend.
  */
-async function restoreChain(storage: AuthClientStorage): Promise<DelegationChain | null> {
+async function restoreChain(
+  storage: AuthClientStorage,
+  syncStorage: AuthClientSyncStorage,
+): Promise<DelegationChain | null> {
   try {
     const raw = await storage.get(KEY_STORAGE_DELEGATION);
     if (!raw || typeof raw !== 'string') return null;
 
     const chain = DelegationChain.fromJSON(raw);
     if (!isDelegationValid(chain)) {
-      await deleteStorage(storage);
+      await deleteStorage(storage, syncStorage);
       return null;
     }
     return chain;
   } catch (e) {
     console.error(e);
-    await deleteStorage(storage);
+    await deleteStorage(storage, syncStorage);
     return null;
   }
 }
@@ -982,23 +1046,32 @@ async function restoreChain(storage: AuthClientStorage): Promise<DelegationChain
  * Clears all session data from storage.
  * @param storage - The storage backend.
  */
-async function deleteStorage(storage: AuthClientStorage): Promise<void> {
+async function deleteStorage(
+  storage: AuthClientStorage,
+  syncStorage: AuthClientSyncStorage,
+): Promise<void> {
   await storage.remove(KEY_STORAGE_KEY);
   await storage.remove(KEY_STORAGE_DELEGATION);
   await storage.remove(KEY_VECTOR);
-  clearCachedExpiration();
+  clearCachedExpiration(syncStorage);
 }
 
 /** Drops the cached expiration, so {@link AuthClient.isAuthenticated} reports no session. */
-function clearCachedExpiration(): void {
-  localStorage.removeItem(KEY_STORAGE_EXPIRATION);
+function clearCachedExpiration(syncStorage: AuthClientSyncStorage): void {
+  syncStorage.remove(KEY_STORAGE_EXPIRATION);
 }
 
 /** Reads the cached delegation expiration from localStorage (nanoseconds). */
-function getExpirationFlag(): bigint | null {
-  const value = localStorage.getItem(KEY_STORAGE_EXPIRATION);
+function getExpirationFlag(syncStorage: AuthClientSyncStorage): bigint | null {
+  const value = syncStorage.get(KEY_STORAGE_EXPIRATION);
   if (value === null) return null;
-  return BigInt(value);
+  try {
+    return BigInt(value);
+  } catch {
+    // A cookie-backed store is writable by every subdomain, so the value may be
+    // anything. isAuthenticated() must not throw on it.
+    return null;
+  }
 }
 
 /**

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,6 +2,7 @@
  * @module api/client
  */
 
+export * from '../shared-session/storage.js';
 export * from './auth-client.js';
 export { type DBCreateOptions, IdbKeyVal } from './db.js';
 export * from './idle-manager.js';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,3 +13,4 @@ export {
   KEY_STORAGE_KEY,
   LocalStorage,
 } from './storage.js';
+export * from './sync-storage.js';

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -56,16 +56,6 @@ export interface SyncCookieStorageOptions {
    * storage and matching key.
    */
   domain: string;
-
-  /**
-   * Derivation origin of the session this store describes.
-   *
-   * It is part of the cookie's name, so two shared sessions below one domain —
-   * a staging deployment beside production — do not write the same cookie and
-   * describe each other's state. Pass the same value given to the session's
-   * storage and to {@link AuthClient}.
-   */
-  derivationOrigin: string | URL;
 }
 
 /**
@@ -78,14 +68,16 @@ export interface SyncCookieStorageOptions {
  * It is readable and writable by every subdomain, and unlike `localStorage` it
  * is not origin-scoped: any of them can overwrite it, and nothing records which
  * one did. Store only values whose authority rests elsewhere.
+ *
+ * The cookie's name is the key it is given, so this assumes one shared session
+ * per domain. Two of them below the same domain would write the same cookie and
+ * describe each other's state.
  * @see implements {@link AuthClientSyncStorage}
  */
 export class SyncCookieStorage implements AuthClientSyncStorage {
   readonly #attributes: string;
-  readonly #suffix: string;
 
   constructor(options: SyncCookieStorageOptions) {
-    this.#suffix = `.${toCookieName(options.derivationOrigin.toString())}`;
     this.#attributes = [
       // Host-only on loopback: browsers reject `Domain=localhost`, and a
       // host-only cookie is already shared across ports, which is what a local
@@ -99,21 +91,17 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
   }
 
   get(key: string): string | null {
-    const name = this.#nameFor(key);
     for (const entry of document.cookie.split(';')) {
       const separator = entry.indexOf('=');
       if (separator === -1) continue;
-      if (decodeURIComponent(entry.slice(0, separator).trim()) !== name) continue;
+      if (decodeURIComponent(entry.slice(0, separator).trim()) !== key) continue;
       return decodeURIComponent(entry.slice(separator + 1).trim());
     }
     return null;
   }
 
   set(key: string, value: string, expiresAt?: number): void {
-    const cookie = [
-      `${encodeURIComponent(this.#nameFor(key))}=${encodeURIComponent(value)}`,
-      this.#attributes,
-    ];
+    const cookie = [`${encodeURIComponent(key)}=${encodeURIComponent(value)}`, this.#attributes];
     if (expiresAt !== undefined) {
       const seconds = Math.floor((expiresAt - Date.now()) / 1000);
       // Already elapsed: writing it would store a value that is untrue on the
@@ -132,26 +120,6 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
 
   remove(key: string): void {
     // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is asynchronous, and this store exists to be read synchronously.
-    document.cookie = `${encodeURIComponent(this.#nameFor(key))}=; ${this.#attributes}; Max-Age=0`;
+    document.cookie = `${encodeURIComponent(key)}=; ${this.#attributes}; Max-Age=0`;
   }
-
-  #nameFor(key: string): string {
-    return `${key}${this.#suffix}`;
-  }
-}
-
-// A cookie name is an RFC 6265 token, so characters an origin may contain — the
-// colon before a port, slashes — are not allowed in one.
-const NON_TOKEN = /[^!#$%&'*+\-.0-9A-Z^_`a-z|~]/g;
-
-function toCookieName(value: string): string {
-  let normalized = value;
-  try {
-    // Reduced to an origin so that a derivation origin written with a trailing
-    // slash or a path does not name a second cookie.
-    normalized = new URL(value).origin;
-  } catch {
-    // Not a URL; used as given.
-  }
-  return normalized.replace(NON_TOKEN, '_');
 }

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -52,7 +52,7 @@ export interface SyncCookieStorageOptions {
    * Must be the current host or a domain above it: a browser rejects a cookie
    * scoped to anything else, including a sibling subdomain. It also refuses a
    * public suffix, so an over-broad value fails rather than leaking to
-   * unrelated sites. Nothing needs to be served at the domain — it is only a
+   * unrelated sites. Nothing needs to be served at the domain, which is only a
    * storage and matching key.
    */
   domain: string;

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -85,7 +85,8 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
       ...(isLoopbackHost(options.domain) ? [] : [`Domain=${options.domain}`]),
       'Path=/',
       'SameSite=Lax',
-      // Loopback is a secure context, but Safari rejects Secure over http.
+      // Loopback is a secure context, but a Secure cookie over http is not
+      // reliably accepted.
       ...(location.protocol === 'https:' ? ['Secure'] : []),
     ].join('; ');
   }

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -1,0 +1,118 @@
+import { isLoopbackHost } from '../shared-session/protocol.js';
+
+/**
+ * Synchronous storage for non-secret values.
+ *
+ * {@link AuthClient.isAuthenticated} answers without awaiting, so what it reads
+ * cannot come from the session store: that one is asynchronous, and with a
+ * shared session it belongs to another origin. Only values that may be read and
+ * written by any script on the domain belong here.
+ */
+export interface AuthClientSyncStorage {
+  get(key: string): string | null;
+
+  /**
+   * @param key - Name to store the value under.
+   * @param value - The value to store.
+   * @param expiresAt - When the value stops being true, in milliseconds since
+   * the epoch. Backends that can expire a value drop it then; others ignore it.
+   */
+  set(key: string, value: string, expiresAt?: number): void;
+
+  remove(key: string): void;
+}
+
+/**
+ * Default synchronous storage, scoped to the current origin.
+ * @see implements {@link AuthClientSyncStorage}
+ */
+export class SyncLocalStorage implements AuthClientSyncStorage {
+  get(key: string): string | null {
+    return localStorage.getItem(key);
+  }
+
+  // localStorage cannot expire a value, so expiresAt is ignored; the value it
+  // holds is a timestamp the reader compares against the current time anyway.
+  set(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+
+  remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+}
+
+export interface SyncCookieStorageOptions {
+  /**
+   * Domain to scope the cookie to, e.g. `example.com` to reach it from
+   * `a.example.com` and `b.example.com`.
+   *
+   * Must be the current host or a domain above it: a browser rejects a cookie
+   * scoped to anything else, including a sibling subdomain. It also refuses a
+   * public suffix, so an over-broad value fails rather than leaking to
+   * unrelated sites.
+   */
+  domain: string;
+}
+
+/**
+ * Synchronous storage shared by a domain and its subdomains.
+ *
+ * A cookie is the only store that is both synchronous and visible across
+ * origins, which is what {@link AuthClient.isAuthenticated} needs when the
+ * session itself lives on another origin.
+ *
+ * It is readable and writable by every subdomain, and unlike `localStorage` it
+ * is not origin-scoped: any of them can overwrite it, and nothing records which
+ * one did. Store only values whose authority rests elsewhere.
+ * @see implements {@link AuthClientSyncStorage}
+ */
+export class SyncCookieStorage implements AuthClientSyncStorage {
+  readonly #attributes: string;
+
+  constructor(options: SyncCookieStorageOptions) {
+    this.#attributes = [
+      // Host-only on loopback: browsers reject `Domain=localhost`, and a
+      // host-only cookie is already shared across ports, which is what a local
+      // multi-origin setup needs.
+      ...(isLoopbackHost(options.domain) ? [] : [`Domain=${options.domain}`]),
+      'Path=/',
+      'SameSite=Lax',
+      // Loopback is a secure context, but Safari rejects Secure over http.
+      ...(location.protocol === 'https:' ? ['Secure'] : []),
+    ].join('; ');
+  }
+
+  get(key: string): string | null {
+    for (const entry of document.cookie.split(';')) {
+      const separator = entry.indexOf('=');
+      if (separator === -1) continue;
+      if (decodeURIComponent(entry.slice(0, separator).trim()) !== key) continue;
+      return decodeURIComponent(entry.slice(separator + 1).trim());
+    }
+    return null;
+  }
+
+  set(key: string, value: string, expiresAt?: number): void {
+    const cookie = [`${encodeURIComponent(key)}=${encodeURIComponent(value)}`, this.#attributes];
+    if (expiresAt !== undefined) {
+      const seconds = Math.floor((expiresAt - Date.now()) / 1000);
+      // Already elapsed: writing it would store a value that is untrue on the
+      // very next read.
+      if (seconds <= 0) {
+        this.remove(key);
+        return;
+      }
+      // The cookie expires with the value it describes, so there is no state in
+      // which it outlives what it is a hint about.
+      cookie.push(`Max-Age=${seconds}`);
+    }
+    // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is asynchronous, and this store exists to be read synchronously.
+    document.cookie = cookie.join('; ');
+  }
+
+  remove(key: string): void {
+    // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is asynchronous, and this store exists to be read synchronously.
+    document.cookie = `${encodeURIComponent(key)}=; ${this.#attributes}; Max-Age=0`;
+  }
+}

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -52,9 +52,24 @@ export interface SyncCookieStorageOptions {
    * Must be the current host or a domain above it: a browser rejects a cookie
    * scoped to anything else, including a sibling subdomain. It also refuses a
    * public suffix, so an over-broad value fails rather than leaking to
-   * unrelated sites.
+   * unrelated sites. Nothing needs to be served at the domain — it is only a
+   * storage and matching key.
    */
   domain: string;
+
+  /**
+   * Distinguishes this store's cookies from another's under the same domain.
+   *
+   * Two shared sessions below one domain — say two hubs, or a staging deployment
+   * beside production — otherwise write the same cookie name and describe each
+   * other's sessions. Pass something that identifies the session, such as the
+   * hub's host.
+   *
+   * A value that parses as a URL is reduced to its origin, so a hub's URL and
+   * its origin name the same cookie. Characters a cookie name cannot carry are
+   * replaced, so either can be passed as-is.
+   */
+  namespace?: string;
 }
 
 /**
@@ -71,8 +86,10 @@ export interface SyncCookieStorageOptions {
  */
 export class SyncCookieStorage implements AuthClientSyncStorage {
   readonly #attributes: string;
+  readonly #suffix: string;
 
   constructor(options: SyncCookieStorageOptions) {
+    this.#suffix = options.namespace === undefined ? '' : `.${toCookieName(options.namespace)}`;
     this.#attributes = [
       // Host-only on loopback: browsers reject `Domain=localhost`, and a
       // host-only cookie is already shared across ports, which is what a local
@@ -86,17 +103,21 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
   }
 
   get(key: string): string | null {
+    const name = this.#nameFor(key);
     for (const entry of document.cookie.split(';')) {
       const separator = entry.indexOf('=');
       if (separator === -1) continue;
-      if (decodeURIComponent(entry.slice(0, separator).trim()) !== key) continue;
+      if (decodeURIComponent(entry.slice(0, separator).trim()) !== name) continue;
       return decodeURIComponent(entry.slice(separator + 1).trim());
     }
     return null;
   }
 
   set(key: string, value: string, expiresAt?: number): void {
-    const cookie = [`${encodeURIComponent(key)}=${encodeURIComponent(value)}`, this.#attributes];
+    const cookie = [
+      `${encodeURIComponent(this.#nameFor(key))}=${encodeURIComponent(value)}`,
+      this.#attributes,
+    ];
     if (expiresAt !== undefined) {
       const seconds = Math.floor((expiresAt - Date.now()) / 1000);
       // Already elapsed: writing it would store a value that is untrue on the
@@ -115,6 +136,26 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
 
   remove(key: string): void {
     // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is asynchronous, and this store exists to be read synchronously.
-    document.cookie = `${encodeURIComponent(key)}=; ${this.#attributes}; Max-Age=0`;
+    document.cookie = `${encodeURIComponent(this.#nameFor(key))}=; ${this.#attributes}; Max-Age=0`;
   }
+
+  #nameFor(key: string): string {
+    return `${key}${this.#suffix}`;
+  }
+}
+
+// A cookie name is an RFC 6265 token, so characters an origin may contain — the
+// colon before a port, slashes — are not allowed in one.
+const NON_TOKEN = /[^!#$%&'*+\-.0-9A-Z^_`a-z|~]/g;
+
+function toCookieName(value: string): string {
+  let normalized = value;
+  try {
+    // Reduced to an origin so that a hub's URL and its origin, which identify
+    // the same shared session, do not name two different cookies.
+    normalized = new URL(value).origin;
+  } catch {
+    // Not a URL; used as given.
+  }
+  return normalized.replace(NON_TOKEN, '_');
 }

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -31,9 +31,11 @@ export class SyncLocalStorage implements AuthClientSyncStorage {
     return localStorage.getItem(key);
   }
 
-  // localStorage cannot expire a value, so expiresAt is ignored; the value it
-  // holds is a timestamp the reader compares against the current time anyway.
-  set(key: string, value: string): void {
+  // Declared but ignored: localStorage cannot expire a value, and dropping the
+  // parameter would make this class unusable where the interface is expected.
+  // The value it holds is a timestamp the reader compares against the current
+  // time anyway.
+  set(key: string, value: string, _expiresAt?: number): void {
     localStorage.setItem(key, value);
   }
 

--- a/src/client/sync-storage.ts
+++ b/src/client/sync-storage.ts
@@ -58,18 +58,14 @@ export interface SyncCookieStorageOptions {
   domain: string;
 
   /**
-   * Distinguishes this store's cookies from another's under the same domain.
+   * Derivation origin of the session this store describes.
    *
-   * Two shared sessions below one domain — say two hubs, or a staging deployment
-   * beside production — otherwise write the same cookie name and describe each
-   * other's sessions. Pass something that identifies the session, such as the
-   * hub's host.
-   *
-   * A value that parses as a URL is reduced to its origin, so a hub's URL and
-   * its origin name the same cookie. Characters a cookie name cannot carry are
-   * replaced, so either can be passed as-is.
+   * It is part of the cookie's name, so two shared sessions below one domain —
+   * a staging deployment beside production — do not write the same cookie and
+   * describe each other's state. Pass the same value given to the session's
+   * storage and to {@link AuthClient}.
    */
-  namespace?: string;
+  derivationOrigin: string | URL;
 }
 
 /**
@@ -89,7 +85,7 @@ export class SyncCookieStorage implements AuthClientSyncStorage {
   readonly #suffix: string;
 
   constructor(options: SyncCookieStorageOptions) {
-    this.#suffix = options.namespace === undefined ? '' : `.${toCookieName(options.namespace)}`;
+    this.#suffix = `.${toCookieName(options.derivationOrigin.toString())}`;
     this.#attributes = [
       // Host-only on loopback: browsers reject `Domain=localhost`, and a
       // host-only cookie is already shared across ports, which is what a local
@@ -151,8 +147,8 @@ const NON_TOKEN = /[^!#$%&'*+\-.0-9A-Z^_`a-z|~]/g;
 function toCookieName(value: string): string {
   let normalized = value;
   try {
-    // Reduced to an origin so that a hub's URL and its origin, which identify
-    // the same shared session, do not name two different cookies.
+    // Reduced to an origin so that a derivation origin written with a trailing
+    // slash or a path does not name a second cookie.
     normalized = new URL(value).origin;
   } catch {
     // Not a URL; used as given.

--- a/src/shared-session/index.ts
+++ b/src/shared-session/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @module api/shared-session
+ */
+
+export { PROTOCOL_VERSION } from './protocol.js';
+export { type ServeSharedSessionOptions, serveSharedSession } from './serve.js';

--- a/src/shared-session/protocol.ts
+++ b/src/shared-session/protocol.ts
@@ -33,12 +33,6 @@ export interface SharedSessionRequest {
   op: SharedSessionOp;
   key: string;
   value?: StoredKey;
-  /**
-   * The client's derivation origin. The hub compares it against its own
-   * configuration and refuses a mismatch: the two sides disagreeing means the
-   * hub is enforcing an allow-list belonging to a different identity.
-   */
-  derivationOrigin: string;
 }
 
 /** The hub's answer to a {@link SharedSessionRequest}. */

--- a/src/shared-session/protocol.ts
+++ b/src/shared-session/protocol.ts
@@ -1,0 +1,106 @@
+import type { StoredKey } from '../client/storage.js';
+
+/** Discriminator for every message exchanged between a client and the hub. */
+export const CHANNEL = 'icp-auth-shared-session';
+
+/**
+ * Wire protocol version.
+ *
+ * A client and a hub are deployed separately and can run different versions of
+ * this package, so both sides check it and refuse a mismatch instead of
+ * misreading each other's payloads.
+ */
+export const PROTOCOL_VERSION = 1;
+
+/** Path of the Internet Identity alternative origins record, relative to the derivation origin. */
+export const ALTERNATIVE_ORIGINS_PATH = '/.well-known/ii-alternative-origins';
+
+/** Internet Identity refuses a record with more entries than this. */
+export const MAX_ALTERNATIVE_ORIGINS = 10;
+
+/** Default time to wait for the hub to answer, in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+export const OPS = ['get', 'set', 'remove'] as const;
+
+export type SharedSessionOp = (typeof OPS)[number];
+
+/** A storage operation, sent from a client to the hub. */
+export interface SharedSessionRequest {
+  v: number;
+  type: typeof CHANNEL;
+  id: number;
+  op: SharedSessionOp;
+  key: string;
+  value?: StoredKey;
+  /**
+   * The client's derivation origin. The hub compares it against its own
+   * configuration and refuses a mismatch: the two sides disagreeing means the
+   * hub is enforcing an allow-list belonging to a different identity.
+   */
+  derivationOrigin: string;
+}
+
+/** The hub's answer to a {@link SharedSessionRequest}. */
+export interface SharedSessionResponse {
+  v: number;
+  type: typeof CHANNEL;
+  id: number;
+  result?: StoredKey | null;
+  error?: string;
+}
+
+/**
+ * Sent by the hub once it is listening.
+ *
+ * Messages without an `id` are reserved for hub-initiated pushes, so a client
+ * that meets a future one ignores it rather than failing to parse it.
+ */
+export interface SharedSessionReady {
+  v: number;
+  type: typeof CHANNEL;
+  ready: true;
+}
+
+export function isChannelMessage(data: unknown): data is { v: unknown; type: typeof CHANNEL } {
+  return typeof data === 'object' && data !== null && (data as { type?: unknown }).type === CHANNEL;
+}
+
+/** Whether a hostname is loopback, which browsers treat as a secure context. */
+export function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]'
+  );
+}
+
+/**
+ * Whether an origin may carry credentials over this protocol.
+ *
+ * `https` only, except for loopback, which local development depends on.
+ */
+export function isSecureOrigin(url: URL): boolean {
+  if (url.protocol === 'https:') return true;
+  return url.protocol === 'http:' && isLoopbackHost(url.hostname);
+}
+
+/**
+ * Parses a bare origin.
+ *
+ * Returns `null` unless the value is a secure origin with nothing else attached:
+ * a path, query, fragment, or embedded credentials means the entry is not the
+ * plain origin it is required to be, and comparing it as one would be wrong.
+ */
+export function parseBareOrigin(value: unknown): URL | null {
+  if (typeof value !== 'string') return null;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.origin !== value || !isSecureOrigin(url)) return null;
+  return url;
+}

--- a/src/shared-session/serve.ts
+++ b/src/shared-session/serve.ts
@@ -27,7 +27,9 @@ export interface ServeSharedSessionOptions {
    * Derivation origin whose session this hub holds.
    *
    * Its `/.well-known/ii-alternative-origins` record lists the origins allowed
-   * to read the session. Clients must be configured with the same value.
+   * to read the session. Those origins must sign in with this same derivation
+   * origin, or they store a session for a principal the others are not
+   * authorized for.
    */
   derivationOrigin: string | URL;
 
@@ -143,15 +145,6 @@ export function serveSharedSession(options: ServeSharedSessionOptions): () => vo
     if (request.v !== PROTOCOL_VERSION) {
       reply({
         error: `unsupported protocol version ${String(request.v)}, this hub speaks ${PROTOCOL_VERSION}`,
-      });
-      return;
-    }
-
-    // Denied before the allow-list is consulted, because a mismatch means the
-    // list this hub holds is not the one that governs the client's identity.
-    if (request.derivationOrigin !== derivationOrigin) {
-      reply({
-        error: `derivation origin mismatch: this hub serves ${derivationOrigin}, the client expects ${String(request.derivationOrigin)}`,
       });
       return;
     }

--- a/src/shared-session/serve.ts
+++ b/src/shared-session/serve.ts
@@ -51,9 +51,9 @@ export interface ServeSharedSessionOptions {
  * `/.well-known/ii-alternative-origins` record.
  *
  * Serve it with a `Content-Security-Policy: frame-ancestors` header naming the
- * origins allowed to embed it. That is defence in depth — the allow-list below
- * is what authorizes a reader — but it stops an unrelated site from loading the
- * page at all.
+ * origins allowed to embed it. That is defence in depth, since the allow-list
+ * below is what authorizes a reader, but it stops an unrelated site from loading
+ * the page at all.
  *
  * @param options - See {@link ServeSharedSessionOptions}.
  * @returns A function that stops serving.
@@ -214,7 +214,7 @@ const CANISTER_ID_HEADER = 'x-ic-canister-id';
  * Where to read the derivation origin's record from.
  *
  * Read through the canister-id gateway URL rather than the derivation origin's
- * own domain, so a boundary node verifies certification — the same precaution
+ * own domain, so a boundary node verifies certification, the same precaution
  * Internet Identity takes when it validates a derivation origin. Reading the
  * custom domain directly would let anyone able to tamper with its responses
  * widen the set of origins allowed to read the session.
@@ -245,8 +245,8 @@ async function alternativeOriginsUrl(derivationOrigin: string): Promise<string> 
  * On a well-known IC domain the canister id is the leftmost label. A custom
  * domain has to be asked: a boundary node answers with the canister id in a
  * response header. That header is not certified, so a party able to tamper with
- * the origin's responses can name a canister of their own — the certified read
- * that follows then verifies the wrong canister's record. Internet Identity
+ * the origin's responses can name a canister of their own, and the certified
+ * read that follows then verifies the wrong canister's record. Internet Identity
  * resolves the same way and inherits the same limit.
  * @param origin - Origin to resolve.
  */

--- a/src/shared-session/serve.ts
+++ b/src/shared-session/serve.ts
@@ -61,8 +61,8 @@ export interface ServeSharedSessionOptions {
 /**
  * Serves the shared session to the origins authorized by the derivation origin.
  *
- * Call this on load from a page deployed at the URL clients pass as
- * `sharedSessionHub`. The page needs nothing else: no markup, no user
+ * Call this on load from a page deployed at the URL clients pass to
+ * `SharedSessionStorage`. The page needs nothing else: no markup, no user
  * interaction, and no state of its own.
  *
  * Serve it with a `Content-Security-Policy: frame-ancestors` header naming the

--- a/src/shared-session/serve.ts
+++ b/src/shared-session/serve.ts
@@ -1,0 +1,248 @@
+import { Principal } from '@icp-sdk/core/principal';
+import { type AuthClientStorage, IdbStorage } from '../client/storage.js';
+import {
+  ALTERNATIVE_ORIGINS_PATH,
+  CHANNEL,
+  isChannelMessage,
+  isLoopbackHost,
+  MAX_ALTERNATIVE_ORIGINS,
+  OPS,
+  PROTOCOL_VERSION,
+  parseBareOrigin,
+  type SharedSessionOp,
+  type SharedSessionRequest,
+  type SharedSessionResponse,
+} from './protocol.js';
+
+/**
+ * The official HTTP gateway.
+ *
+ * Requests to a canister-id subdomain of this domain pass a boundary node that
+ * verifies asset certification; a custom domain does not carry that guarantee.
+ */
+const IC_HTTP_GATEWAY_DOMAIN = 'icp0.io';
+
+export interface ServeSharedSessionOptions {
+  /**
+   * Derivation origin whose session this hub holds.
+   *
+   * Its `/.well-known/ii-alternative-origins` record lists the origins allowed
+   * to read the session. Clients must be configured with the same value.
+   */
+  derivationOrigin: string | URL;
+
+  /**
+   * Canister id serving the derivation origin.
+   *
+   * Only used when the derivation origin is a different origin than this page.
+   * Supplying it makes the allow-list read through the official gateway, which
+   * verifies certification — without it, anyone able to tamper with responses
+   * from the derivation origin can widen the set of readers. Internet Identity
+   * takes the same precaution when it validates a derivation origin.
+   */
+  canisterId?: string;
+
+  /**
+   * Store holding the shared session.
+   * @default IdbStorage
+   */
+  storage?: AuthClientStorage;
+
+  /**
+   * Replaces discovery of the allow-list. Intended for tests and for
+   * deployments that publish the record elsewhere.
+   *
+   * The returned origins are the only ones served, alongside the derivation
+   * origin itself.
+   */
+  allowedOrigins?: () => Promise<string[]>;
+}
+
+/**
+ * Serves the shared session to the origins authorized by the derivation origin.
+ *
+ * Call this on load from a page deployed at the URL clients pass as
+ * `sharedSessionHub`. The page needs nothing else: no markup, no user
+ * interaction, and no state of its own.
+ *
+ * Serve it with a `Content-Security-Policy: frame-ancestors` header naming the
+ * origins allowed to embed it. That is defence in depth — the allow-list below
+ * is what authorizes a reader — but it stops an unrelated site from loading the
+ * page at all.
+ *
+ * @param options - See {@link ServeSharedSessionOptions}.
+ * @returns A function that stops serving.
+ *
+ * @example
+ * ```ts
+ * import { serveSharedSession } from '@icp-sdk/auth/shared-session';
+ *
+ * serveSharedSession({
+ *   derivationOrigin: 'https://auth.example.com',
+ *   canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
+ * });
+ * ```
+ */
+export function serveSharedSession(options: ServeSharedSessionOptions): () => void {
+  const storage = options.storage ?? new IdbStorage();
+  const derivationOrigin = new URL(options.derivationOrigin.toString()).origin;
+  if (options.canisterId !== undefined) {
+    try {
+      Principal.fromText(options.canisterId);
+    } catch {
+      throw new Error(
+        `Shared session canisterId is not a valid principal: "${options.canisterId}".`,
+      );
+    }
+  }
+  const discover =
+    options.allowedOrigins ?? (() => fetchAlternativeOrigins(derivationOrigin, options.canisterId));
+
+  let discovered: Promise<Set<string>> | null = null;
+  // Memoized, but a failure is not cached: a transient error must not deny every
+  // client until this page reloads.
+  const allowedOrigins = (): Promise<Set<string>> => {
+    if (discovered === null) {
+      const pending = discover().then(
+        (origins) =>
+          new Set(
+            [derivationOrigin, ...origins]
+              .map((origin) => parseBareOrigin(origin)?.origin)
+              .filter((origin): origin is string => origin !== undefined),
+          ),
+      );
+      pending.catch(() => {
+        if (discovered === pending) {
+          discovered = null;
+        }
+      });
+      discovered = pending;
+    }
+    return discovered;
+  };
+
+  const onMessage = async (event: MessageEvent): Promise<void> => {
+    const source = event.source as Window | null;
+    if (source === null || !isChannelMessage(event.data)) return;
+
+    const request = event.data as Partial<SharedSessionRequest>;
+    // A ready announcement or a future hub-initiated push is not a request.
+    if (request.id === undefined) return;
+
+    const origin = event.origin;
+    const reply = (body: Partial<SharedSessionResponse>): void => {
+      const response: SharedSessionResponse = {
+        v: PROTOCOL_VERSION,
+        type: CHANNEL,
+        id: request.id as number,
+        ...body,
+      };
+      source.postMessage(response, origin);
+    };
+
+    if (request.v !== PROTOCOL_VERSION) {
+      reply({
+        error: `unsupported protocol version ${String(request.v)}, this hub speaks ${PROTOCOL_VERSION}`,
+      });
+      return;
+    }
+
+    // Denied before the allow-list is consulted, because a mismatch means the
+    // list this hub holds is not the one that governs the client's identity.
+    if (request.derivationOrigin !== derivationOrigin) {
+      reply({
+        error: `derivation origin mismatch: this hub serves ${derivationOrigin}, the client expects ${String(request.derivationOrigin)}`,
+      });
+      return;
+    }
+
+    const permitted = await allowedOrigins()
+      .then((origins) => origins.has(origin))
+      .catch(() => false);
+    const op = request.op;
+    if (!permitted || op === undefined || !OPS.includes(op) || typeof request.key !== 'string') {
+      reply({ error: 'denied' });
+      return;
+    }
+
+    try {
+      reply({ result: await apply(storage, op, request.key, request.value) });
+    } catch (error) {
+      reply({ error: `${op} failed: ${String(error)}` });
+    }
+  };
+
+  const listener = (event: MessageEvent): void => {
+    void onMessage(event);
+  };
+  addEventListener('message', listener);
+
+  // Announced to whoever embeds this page: it carries no session data, and the
+  // embedder's origin cannot be known until it identifies itself.
+  parent.postMessage({ v: PROTOCOL_VERSION, type: CHANNEL, ready: true }, '*');
+
+  return () => removeEventListener('message', listener);
+}
+
+async function apply(
+  storage: AuthClientStorage,
+  op: SharedSessionOp,
+  key: string,
+  value: SharedSessionRequest['value'],
+): Promise<SharedSessionResponse['result']> {
+  switch (op) {
+    case 'get':
+      return await storage.get(key);
+    case 'set':
+      if (value === undefined) throw new Error('set requires a value');
+      await storage.set(key, value);
+      return null;
+    case 'remove':
+      await storage.remove(key);
+      return null;
+  }
+}
+
+async function fetchAlternativeOrigins(
+  derivationOrigin: string,
+  canisterId: string | undefined,
+): Promise<string[]> {
+  const url = alternativeOriginsUrl(derivationOrigin, canisterId);
+  const response = await fetch(url, {
+    // A redirect would move the record to an origin that never vouched for it.
+    redirect: 'error',
+    credentials: 'omit',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`${url} returned status ${response.status}`);
+  }
+
+  const record = (await response.json()) as { alternativeOrigins?: unknown };
+  if (!Array.isArray(record?.alternativeOrigins)) {
+    throw new Error(`${url} has no alternativeOrigins array`);
+  }
+  if (record.alternativeOrigins.length > MAX_ALTERNATIVE_ORIGINS) {
+    throw new Error(
+      `${url} lists more than ${MAX_ALTERNATIVE_ORIGINS} origins, which Internet Identity rejects`,
+    );
+  }
+  return record.alternativeOrigins;
+}
+
+function alternativeOriginsUrl(derivationOrigin: string, canisterId: string | undefined): string {
+  // Same origin: the record's integrity is this page's own. Anyone able to
+  // rewrite it can rewrite this bundle, so the gateway adds nothing.
+  if (derivationOrigin === location.origin) {
+    return ALTERNATIVE_ORIGINS_PATH;
+  }
+  if (canisterId !== undefined) {
+    return `https://${canisterId}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
+  }
+  if (!isLoopbackHost(new URL(derivationOrigin).hostname)) {
+    console.warn(
+      `Reading ${derivationOrigin}${ALTERNATIVE_ORIGINS_PATH} without certification. Pass canisterId so the allow-list is read through ${IC_HTTP_GATEWAY_DOMAIN}, otherwise tampering with that origin's responses can widen who may read the shared session.`,
+    );
+  }
+  return `${derivationOrigin}${ALTERNATIVE_ORIGINS_PATH}`;
+}

--- a/src/shared-session/serve.ts
+++ b/src/shared-session/serve.ts
@@ -14,35 +14,14 @@ import {
   type SharedSessionResponse,
 } from './protocol.js';
 
-/**
- * The official HTTP gateway.
- *
- * Requests to a canister-id subdomain of this domain pass a boundary node that
- * verifies asset certification; a custom domain does not carry that guarantee.
- */
-const IC_HTTP_GATEWAY_DOMAIN = 'icp0.io';
-
 export interface ServeSharedSessionOptions {
   /**
    * Derivation origin whose session this hub holds.
    *
-   * Its `/.well-known/ii-alternative-origins` record lists the origins allowed
-   * to read the session. Those origins must sign in with this same derivation
-   * origin, or they store a session for a principal the others are not
-   * authorized for.
+   * Its `/.well-known/ii-alternative-origins` record decides which origins may
+   * read the session. Clients must sign in with this same value.
    */
   derivationOrigin: string | URL;
-
-  /**
-   * Canister id serving the derivation origin.
-   *
-   * Only used when the derivation origin is a different origin than this page.
-   * Supplying it makes the allow-list read through the official gateway, which
-   * verifies certification — without it, anyone able to tamper with responses
-   * from the derivation origin can widen the set of readers. Internet Identity
-   * takes the same precaution when it validates a derivation origin.
-   */
-  canisterId?: string;
 
   /**
    * Store holding the shared session.
@@ -61,11 +40,15 @@ export interface ServeSharedSessionOptions {
 }
 
 /**
- * Serves the shared session to the origins authorized by the derivation origin.
+ * Serves the shared session to the origins authorized by this origin.
  *
  * Call this on load from a page deployed at the URL clients pass to
  * `SharedSessionStorage`. The page needs nothing else: no markup, no user
  * interaction, and no state of its own.
+ *
+ * The page may be served from any origin; the derivation origin decides which
+ * origins may read the session, through its
+ * `/.well-known/ii-alternative-origins` record.
  *
  * Serve it with a `Content-Security-Policy: frame-ancestors` header naming the
  * origins allowed to embed it. That is defence in depth — the allow-list below
@@ -79,26 +62,13 @@ export interface ServeSharedSessionOptions {
  * ```ts
  * import { serveSharedSession } from '@icp-sdk/auth/shared-session';
  *
- * serveSharedSession({
- *   derivationOrigin: 'https://auth.example.com',
- *   canisterId: 'rdmx6-jaaaa-aaaaa-aaadq-cai',
- * });
+ * serveSharedSession({ derivationOrigin: 'https://auth.example.com' });
  * ```
  */
 export function serveSharedSession(options: ServeSharedSessionOptions): () => void {
   const storage = options.storage ?? new IdbStorage();
   const derivationOrigin = new URL(options.derivationOrigin.toString()).origin;
-  if (options.canisterId !== undefined) {
-    try {
-      Principal.fromText(options.canisterId);
-    } catch {
-      throw new Error(
-        `Shared session canisterId is not a valid principal: "${options.canisterId}".`,
-      );
-    }
-  }
-  const discover =
-    options.allowedOrigins ?? (() => fetchAlternativeOrigins(derivationOrigin, options.canisterId));
+  const discover = options.allowedOrigins ?? (() => fetchAlternativeOrigins(derivationOrigin));
 
   let discovered: Promise<Set<string>> | null = null;
   // Memoized, but a failure is not cached: a transient error must not deny every
@@ -196,11 +166,8 @@ async function apply(
   }
 }
 
-async function fetchAlternativeOrigins(
-  derivationOrigin: string,
-  canisterId: string | undefined,
-): Promise<string[]> {
-  const url = alternativeOriginsUrl(derivationOrigin, canisterId);
+async function fetchAlternativeOrigins(derivationOrigin: string): Promise<string[]> {
+  const url = await alternativeOriginsUrl(derivationOrigin);
   const response = await fetch(url, {
     // A redirect would move the record to an origin that never vouched for it.
     redirect: 'error',
@@ -223,19 +190,100 @@ async function fetchAlternativeOrigins(
   return record.alternativeOrigins;
 }
 
-function alternativeOriginsUrl(derivationOrigin: string, canisterId: string | undefined): string {
-  // Same origin: the record's integrity is this page's own. Anyone able to
-  // rewrite it can rewrite this bundle, so the gateway adds nothing.
+/**
+ * The official HTTP gateway.
+ *
+ * A request to a canister-id subdomain of it passes a boundary node that
+ * verifies asset certification; a custom domain carries no such guarantee.
+ */
+const IC_HTTP_GATEWAY_DOMAIN = 'icp0.io';
+
+/** Domains where the canister id is the leftmost label of the hostname. */
+const WELL_KNOWN_IC_DOMAINS = [
+  'ic0.app',
+  'icp0.io',
+  'icp.net',
+  'internetcomputer.org',
+  'localhost',
+];
+
+/** Header a boundary node sets to name the canister serving a custom domain. */
+const CANISTER_ID_HEADER = 'x-ic-canister-id';
+
+/**
+ * Where to read the derivation origin's record from.
+ *
+ * Read through the canister-id gateway URL rather than the derivation origin's
+ * own domain, so a boundary node verifies certification — the same precaution
+ * Internet Identity takes when it validates a derivation origin. Reading the
+ * custom domain directly would let anyone able to tamper with its responses
+ * widen the set of origins allowed to read the session.
+ * @param derivationOrigin - Origin whose record is wanted.
+ */
+async function alternativeOriginsUrl(derivationOrigin: string): Promise<string> {
+  // This page's own origin: the record's integrity is already this page's, so
+  // anyone able to rewrite it can rewrite this bundle and the gateway adds
+  // nothing.
   if (derivationOrigin === location.origin) {
     return ALTERNATIVE_ORIGINS_PATH;
   }
-  if (canisterId !== undefined) {
-    return `https://${canisterId}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
+
+  const url = new URL(derivationOrigin);
+  const canisterId = await resolveCanisterId(url);
+
+  // A local replica serves every canister from one host, so the canister is
+  // named by query parameter instead of by subdomain.
+  if (isLoopbackHost(url.hostname)) {
+    return `${url.origin}${ALTERNATIVE_ORIGINS_PATH}?canisterId=${canisterId.toText()}`;
   }
-  if (!isLoopbackHost(new URL(derivationOrigin).hostname)) {
-    console.warn(
-      `Reading ${derivationOrigin}${ALTERNATIVE_ORIGINS_PATH} without certification. Pass canisterId so the allow-list is read through ${IC_HTTP_GATEWAY_DOMAIN}, otherwise tampering with that origin's responses can widen who may read the shared session.`,
-    );
+  return `https://${canisterId.toText()}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
+}
+
+/**
+ * Resolves the canister serving an origin.
+ *
+ * On a well-known IC domain the canister id is the leftmost label. A custom
+ * domain has to be asked: a boundary node answers with the canister id in a
+ * response header. That header is not certified, so a party able to tamper with
+ * the origin's responses can name a canister of their own — the certified read
+ * that follows then verifies the wrong canister's record. Internet Identity
+ * resolves the same way and inherits the same limit.
+ * @param origin - Origin to resolve.
+ */
+async function resolveCanisterId(origin: URL): Promise<Principal> {
+  const fromHostname = canisterIdFromHostname(origin.hostname);
+  if (fromHostname !== undefined) {
+    return fromHostname;
   }
-  return `${derivationOrigin}${ALTERNATIVE_ORIGINS_PATH}`;
+
+  const response = await fetch(origin.origin, { method: 'HEAD', credentials: 'omit' });
+  const header = response.headers.get(CANISTER_ID_HEADER);
+  if (header === null) {
+    throw new Error(`${origin.origin} did not answer with a ${CANISTER_ID_HEADER} header`);
+  }
+  try {
+    return Principal.fromText(header);
+  } catch {
+    throw new Error(`${origin.origin} answered with an invalid ${CANISTER_ID_HEADER}: "${header}"`);
+  }
+}
+
+function canisterIdFromHostname(hostname: string): Principal | undefined {
+  // Matched on a dot boundary, so a lookalike such as `evil-ic0.app` is not
+  // taken for a well-known IC domain.
+  const wellKnown = WELL_KNOWN_IC_DOMAINS.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+  );
+  if (!wellKnown) return undefined;
+
+  const [first, ...rest] = hostname.split('.');
+  // No subdomain to read a canister id from.
+  if (rest.length === 0) return undefined;
+  try {
+    return Principal.fromText(first);
+  } catch {
+    // Not a canister id, so the origin is a custom domain on one of these hosts
+    // and has to be asked instead.
+    return undefined;
+  }
 }

--- a/src/shared-session/storage.ts
+++ b/src/shared-session/storage.ts
@@ -21,15 +21,6 @@ export interface SharedSessionStorageOptions {
   url: string | URL;
 
   /**
-   * Derivation origin the shared session belongs to.
-   *
-   * The hub authorizes readers from this origin's
-   * `/.well-known/ii-alternative-origins` record, and refuses a client whose
-   * derivation origin differs from the one it was configured with.
-   */
-  derivationOrigin: string | URL;
-
-  /**
    * Time to wait for the hub to load and to answer each operation, in milliseconds.
    * @default 10000
    */
@@ -45,6 +36,11 @@ export interface SharedSessionStorageOptions {
  * and no credential is ever attached to an HTTP request.
  *
  * @see {@link https://js.icp.build/auth/}
+ * Which origins may read it is decided by the hub, from the
+ * `/.well-known/ii-alternative-origins` record of the derivation origin it was
+ * configured with. This origin must be listed there, and must sign in with that
+ * same derivation origin, or it stores a session for a principal the hub's
+ * readers are not authorized for.
  * @example
  * ```ts
  * const derivationOrigin = 'https://auth.example.com';
@@ -52,10 +48,7 @@ export interface SharedSessionStorageOptions {
  * const authClient = new AuthClient({
  *   storage: new SharedSessionStorage({
  *     url: 'https://auth.example.com/shared-session.html',
- *     derivationOrigin,
  *   }),
- *   // The same value, or this client would sign in as a principal the hub's
- *   // store is not authorized for.
  *   derivationOrigin,
  * });
  * ```
@@ -63,7 +56,6 @@ export interface SharedSessionStorageOptions {
 export class SharedSessionStorage implements AuthClientStorage {
   readonly #hubUrl: URL;
   readonly #hubOrigin: string;
-  readonly #derivationOrigin: string;
   readonly #timeout: number;
   #connection: Promise<Window> | null = null;
   #lastId = 0;
@@ -76,7 +68,6 @@ export class SharedSessionStorage implements AuthClientStorage {
       );
     }
     this.#hubOrigin = this.#hubUrl.origin;
-    this.#derivationOrigin = parseAbsoluteUrl(options.derivationOrigin, 'derivationOrigin').origin;
     this.#timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
   }
 
@@ -102,7 +93,6 @@ export class SharedSessionStorage implements AuthClientStorage {
       op,
       key,
       value,
-      derivationOrigin: this.#derivationOrigin,
     };
 
     return await new Promise<StoredKey | null>((resolve, reject) => {

--- a/src/shared-session/storage.ts
+++ b/src/shared-session/storage.ts
@@ -11,26 +11,14 @@ import {
   type SharedSessionResponse,
 } from './protocol.js';
 
-/** Location of the page that calls `serveSharedSession`. */
-export interface SharedSessionHubOptions {
+export interface SharedSessionStorageOptions {
   /**
-   * Absolute URL of the hub page, e.g.
-   * `https://auth.example.com/.well-known/icp-auth-storage.html`.
+   * Absolute URL of the page that calls `serveSharedSession`, e.g.
+   * `https://auth.example.com/shared-session.html`.
    *
    * Must be `https`, except on loopback for local development.
    */
   url: string | URL;
-
-  /**
-   * Time to wait for the hub to load and to answer each operation, in milliseconds.
-   * @default 10000
-   */
-  timeout?: number;
-}
-
-export interface SharedSessionStorageOptions {
-  /** Where the shared session is served from. */
-  hub: SharedSessionHubOptions;
 
   /**
    * Derivation origin the shared session belongs to.
@@ -40,6 +28,12 @@ export interface SharedSessionStorageOptions {
    * derivation origin differs from the one it was configured with.
    */
   derivationOrigin: string | URL;
+
+  /**
+   * Time to wait for the hub to load and to answer each operation, in milliseconds.
+   * @default 10000
+   */
+  timeout?: number;
 }
 
 /**
@@ -57,7 +51,7 @@ export interface SharedSessionStorageOptions {
  *
  * const authClient = new AuthClient({
  *   storage: new SharedSessionStorage({
- *     hub: { url: 'https://auth.example.com/hub.html' },
+ *     url: 'https://auth.example.com/shared-session.html',
  *     derivationOrigin,
  *   }),
  *   // The same value, or this client would sign in as a principal the hub's
@@ -75,7 +69,7 @@ export class SharedSessionStorage implements AuthClientStorage {
   #lastId = 0;
 
   constructor(options: SharedSessionStorageOptions) {
-    this.#hubUrl = parseAbsoluteUrl(options.hub.url, 'hub.url');
+    this.#hubUrl = parseAbsoluteUrl(options.url, 'url');
     if (!isSecureOrigin(this.#hubUrl)) {
       throw new Error(
         `Shared session hub must be served over https (or loopback for local development), got "${this.#hubUrl.origin}".`,
@@ -83,18 +77,7 @@ export class SharedSessionStorage implements AuthClientStorage {
     }
     this.#hubOrigin = this.#hubUrl.origin;
     this.#derivationOrigin = parseAbsoluteUrl(options.derivationOrigin, 'derivationOrigin').origin;
-    this.#timeout = options.hub.timeout ?? DEFAULT_TIMEOUT_MS;
-  }
-
-  /**
-   * Origin serving this shared session.
-   *
-   * Identifies the session among any others under the same domain: pass it as
-   * the `namespace` of a `SyncCookieStorage` so two hubs do not describe each
-   * other's sessions.
-   */
-  get hubOrigin(): string {
-    return this.#hubOrigin;
+    this.#timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
   }
 
   async get(key: string): Promise<StoredKey | null> {

--- a/src/shared-session/storage.ts
+++ b/src/shared-session/storage.ts
@@ -53,9 +53,16 @@ export interface SharedSessionStorageOptions {
  * @see {@link https://js.icp.build/auth/}
  * @example
  * ```ts
+ * const derivationOrigin = 'https://auth.example.com';
+ *
  * const authClient = new AuthClient({
- *   sharedSessionHub: { url: 'https://auth.example.com/hub.html' },
- *   derivationOrigin: 'https://auth.example.com',
+ *   storage: new SharedSessionStorage({
+ *     hub: { url: 'https://auth.example.com/hub.html' },
+ *     derivationOrigin,
+ *   }),
+ *   // The same value, or this client would sign in as a principal the hub's
+ *   // store is not authorized for.
+ *   derivationOrigin,
  * });
  * ```
  */
@@ -77,6 +84,17 @@ export class SharedSessionStorage implements AuthClientStorage {
     this.#hubOrigin = this.#hubUrl.origin;
     this.#derivationOrigin = parseAbsoluteUrl(options.derivationOrigin, 'derivationOrigin').origin;
     this.#timeout = options.hub.timeout ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * Origin serving this shared session.
+   *
+   * Identifies the session among any others under the same domain: pass it as
+   * the `namespace` of a `SyncCookieStorage` so two hubs do not describe each
+   * other's sessions.
+   */
+  get hubOrigin(): string {
+    return this.#hubOrigin;
   }
 
   async get(key: string): Promise<StoredKey | null> {

--- a/src/shared-session/storage.ts
+++ b/src/shared-session/storage.ts
@@ -1,0 +1,244 @@
+import type { AuthClientStorage, StoredKey } from '../client/storage.js';
+import {
+  CHANNEL,
+  DEFAULT_TIMEOUT_MS,
+  isChannelMessage,
+  isSecureOrigin,
+  PROTOCOL_VERSION,
+  type SharedSessionOp,
+  type SharedSessionReady,
+  type SharedSessionRequest,
+  type SharedSessionResponse,
+} from './protocol.js';
+
+/** Location of the page that calls `serveSharedSession`. */
+export interface SharedSessionHubOptions {
+  /**
+   * Absolute URL of the hub page, e.g.
+   * `https://auth.example.com/.well-known/icp-auth-storage.html`.
+   *
+   * Must be `https`, except on loopback for local development.
+   */
+  url: string | URL;
+
+  /**
+   * Time to wait for the hub to load and to answer each operation, in milliseconds.
+   * @default 10000
+   */
+  timeout?: number;
+}
+
+export interface SharedSessionStorageOptions {
+  /** Where the shared session is served from. */
+  hub: SharedSessionHubOptions;
+
+  /**
+   * Derivation origin the shared session belongs to.
+   *
+   * The hub authorizes readers from this origin's
+   * `/.well-known/ii-alternative-origins` record, and refuses a client whose
+   * derivation origin differs from the one it was configured with.
+   */
+  derivationOrigin: string | URL;
+}
+
+/**
+ * Keeps the session in a store hosted by another origin, so every origin
+ * authorized by the derivation origin shares one sign-in.
+ *
+ * The store itself lives in the hub page's IndexedDB; this class only proxies
+ * operations to it over `postMessage`. Nothing is written on the calling origin,
+ * and no credential is ever attached to an HTTP request.
+ *
+ * @see {@link https://js.icp.build/auth/}
+ * @example
+ * ```ts
+ * const authClient = new AuthClient({
+ *   sharedSessionHub: { url: 'https://auth.example.com/hub.html' },
+ *   derivationOrigin: 'https://auth.example.com',
+ * });
+ * ```
+ */
+export class SharedSessionStorage implements AuthClientStorage {
+  readonly #hubUrl: URL;
+  readonly #hubOrigin: string;
+  readonly #derivationOrigin: string;
+  readonly #timeout: number;
+  #connection: Promise<Window> | null = null;
+  #lastId = 0;
+
+  constructor(options: SharedSessionStorageOptions) {
+    this.#hubUrl = parseAbsoluteUrl(options.hub.url, 'hub.url');
+    if (!isSecureOrigin(this.#hubUrl)) {
+      throw new Error(
+        `Shared session hub must be served over https (or loopback for local development), got "${this.#hubUrl.origin}".`,
+      );
+    }
+    this.#hubOrigin = this.#hubUrl.origin;
+    this.#derivationOrigin = parseAbsoluteUrl(options.derivationOrigin, 'derivationOrigin').origin;
+    this.#timeout = options.hub.timeout ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async get(key: string): Promise<StoredKey | null> {
+    return await this.#call('get', key);
+  }
+
+  async set(key: string, value: StoredKey): Promise<void> {
+    await this.#call('set', key, value);
+  }
+
+  async remove(key: string): Promise<void> {
+    await this.#call('remove', key);
+  }
+
+  async #call(op: SharedSessionOp, key: string, value?: StoredKey): Promise<StoredKey | null> {
+    const hub = await this.#connect();
+    const id = ++this.#lastId;
+    const request: SharedSessionRequest = {
+      v: PROTOCOL_VERSION,
+      type: CHANNEL,
+      id,
+      op,
+      key,
+      value,
+      derivationOrigin: this.#derivationOrigin,
+    };
+
+    return await new Promise<StoredKey | null>((resolve, reject) => {
+      const settle = (finish: () => void) => {
+        clearTimeout(timer);
+        removeEventListener('message', onMessage);
+        finish();
+      };
+
+      const onMessage = (event: MessageEvent) => {
+        if (event.origin !== this.#hubOrigin || !isChannelMessage(event.data)) return;
+        const data = event.data as Partial<SharedSessionResponse>;
+        if (data.id !== id) return;
+        settle(() => {
+          if (data.error !== undefined) {
+            reject(new Error(`Shared session hub refused ${op}: ${data.error}`));
+            return;
+          }
+          resolve(data.result ?? null);
+        });
+      };
+
+      const timer = setTimeout(() => {
+        settle(() =>
+          reject(
+            new Error(
+              `Shared session hub at ${this.#hubUrl.toString()} did not answer ${op} within ${this.#timeout}ms.`,
+            ),
+          ),
+        );
+      }, this.#timeout);
+
+      addEventListener('message', onMessage);
+      hub.postMessage(request, this.#hubOrigin);
+    });
+  }
+
+  // Memoized, but a failure is not cached: a hub that was briefly unreachable
+  // must not leave this client unable to reach it for the page's lifetime.
+  #connect(): Promise<Window> {
+    if (this.#connection === null) {
+      const connection = this.#openHub();
+      connection.catch(() => {
+        if (this.#connection === connection) {
+          this.#connection = null;
+        }
+      });
+      this.#connection = connection;
+    }
+    return this.#connection;
+  }
+
+  async #openHub(): Promise<Window> {
+    await bodyReady();
+
+    const frame = document.createElement('iframe');
+    frame.hidden = true;
+    frame.setAttribute('aria-hidden', 'true');
+    frame.setAttribute('tabindex', '-1');
+    frame.title = 'Shared session';
+    frame.src = this.#hubUrl.toString();
+
+    const ready = new Promise<Window>((resolve, reject) => {
+      const settle = (finish: () => void) => {
+        clearTimeout(timer);
+        removeEventListener('message', onMessage);
+        finish();
+      };
+
+      const onMessage = (event: MessageEvent) => {
+        // Checking the source as well as the origin: another frame on the hub's
+        // origin must not be able to answer for this one.
+        if (event.origin !== this.#hubOrigin || event.source !== frame.contentWindow) return;
+        if (!isChannelMessage(event.data)) return;
+        const data = event.data as Partial<SharedSessionReady>;
+        if (data.ready !== true) return;
+
+        settle(() => {
+          if (data.v !== PROTOCOL_VERSION) {
+            reject(
+              new Error(
+                `Shared session hub at ${this.#hubUrl.toString()} speaks protocol version ${String(data.v)}, this client speaks ${PROTOCOL_VERSION}. Align the @icp-sdk/auth version deployed on both origins.`,
+              ),
+            );
+            return;
+          }
+          const target = frame.contentWindow;
+          if (target === null) {
+            reject(
+              new Error(`Shared session hub at ${this.#hubUrl.toString()} closed while loading.`),
+            );
+            return;
+          }
+          resolve(target);
+        });
+      };
+
+      // A missing hub page still fires `load` on the iframe, so there is nothing
+      // to listen for other than the handshake itself: a wrong URL, a redirect,
+      // or a page that never calls `serveSharedSession` all present as silence.
+      const timer = setTimeout(() => {
+        settle(() =>
+          reject(
+            new Error(
+              `Shared session hub at ${this.#hubUrl.toString()} did not respond within ${this.#timeout}ms. Check that the page is deployed at that URL, is not redirected, and calls serveSharedSession().`,
+            ),
+          ),
+        );
+      }, this.#timeout);
+
+      addEventListener('message', onMessage);
+    });
+
+    document.body.append(frame);
+    try {
+      return await ready;
+    } catch (error) {
+      // Nothing will ever answer through this frame, and #connect allows a
+      // retry, so leaving it attached would accumulate one dead frame per
+      // attempt.
+      frame.remove();
+      throw error;
+    }
+  }
+}
+
+function parseAbsoluteUrl(value: string | URL, label: string): URL {
+  try {
+    return new URL(value.toString());
+  } catch {
+    throw new Error(`Shared session ${label} must be an absolute URL, got "${value.toString()}".`);
+  }
+}
+
+function bodyReady(): Promise<void> {
+  if (document.body !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    document.addEventListener('DOMContentLoaded', () => resolve(), { once: true });
+  });
+}

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -769,13 +769,10 @@ describe('AuthClient shared session', () => {
     });
   });
 
-  /**
-   * Seeds the cross-origin expiration hint the way another origin would. The
-   * name carries the derivation origin, so it must match what the store builds.
-   */
+  /** Seeds the cross-origin expiration hint the way another origin would. */
   const setExpirationCookie = (value: string): void => {
     // biome-ignore lint/suspicious/noDocumentCookie: seeding the store the client reads synchronously.
-    document.cookie = `${EXPIRATION_KEY}.https___example.com=${value}; Path=/`;
+    document.cookie = `${EXPIRATION_KEY}=${value}; Path=/`;
   };
 
   afterEach(() => {
@@ -837,7 +834,6 @@ describe('AuthClient shared session', () => {
     const client = new AuthClient({
       storage: new SharedSessionStorage({
         url: 'https://auth.example.com/shared-session.html',
-        derivationOrigin: 'https://auth.example.com',
         timeout: 300,
       }),
       derivationOrigin: 'https://auth.example.com',
@@ -866,10 +862,7 @@ describe('AuthClient shared session', () => {
     expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
 
     const client = new AuthClient({
-      syncStorage: new SyncCookieStorage({
-        domain: 'localhost',
-        derivationOrigin: 'https://example.com',
-      }),
+      syncStorage: new SyncCookieStorage({ domain: 'localhost' }),
       idleOptions: { disableIdle: true },
     });
 

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -892,7 +892,22 @@ describe('AuthClient shared session', () => {
     await settleHydration(client);
   });
 
-  it('falls back to localStorage when the derivation origin is a sibling domain', async () => {
+  it('scopes the cookie to the hub, not the derivation origin', async () => {
+    // The hub is at-or-above this origin while the derivation origin is an
+    // unrelated domain, so only following the hub reaches a usable cookie.
+    setExpirationCookie(futureExpirationNs());
+    const client = new AuthClient({
+      sharedSessionHub: { url: 'http://localhost:4000/hub.html', timeout: 30 },
+      derivationOrigin: 'https://example2.com',
+      idleOptions: { disableIdle: true },
+    });
+
+    expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
+    expect(client.isAuthenticated()).toBe(true);
+    await settleHydration(client);
+  });
+
+  it('falls back to localStorage when the hub is on a sibling domain', async () => {
     // A cookie for auth.localhost cannot be written from jsdom's localhost
     // origin, so a cookie-backed store would never read back what it wrote.
     const client = new AuthClient({

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -799,13 +799,24 @@ describe('AuthClient shared session', () => {
     expect(client.isAuthenticated()).toBe(true);
   });
 
-  it('clears a stale expiration when the session is no longer in the store', async () => {
-    // Another origin signed out, which cannot reach this origin's localStorage.
+  it('keeps the cached expiration when the store is empty', async () => {
+    // With a shared session the cache is shared too, so an origin that cannot
+    // see the session must not delete the hint the others rely on. The cache
+    // carries the delegation's expiry and lapses on its own.
     localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
     const client = new AuthClient({ storage: fakeStore(), idleOptions: { disableIdle: true } });
-    expect(client.isAuthenticated()).toBe(true);
 
-    await client.getIdentity();
+    const identity = await client.getIdentity();
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(true);
+    expect(client.isAuthenticated()).toBe(true);
+  });
+
+  it('clears the cached expiration on sign out', async () => {
+    localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
+    const client = new AuthClient({ storage: fakeStore(), idleOptions: { disableIdle: true } });
+
+    await client.signOut();
 
     expect(client.isAuthenticated()).toBe(false);
   });

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -11,6 +11,8 @@ import {
   KEY_STORAGE_KEY,
   LocalStorage,
 } from '../../src/client/storage.ts';
+import { SyncCookieStorage } from '../../src/client/sync-storage.ts';
+import { SharedSessionStorage } from '../../src/shared-session/storage.ts';
 import { FakeTransport } from './fake-transport.ts';
 
 // Swap `PostMessageTransport` for `FakeTransport` so `AuthClient` uses the real
@@ -767,16 +769,6 @@ describe('AuthClient shared session', () => {
     });
   });
 
-  /**
-   * Waits for hydration to finish. A hub that never answers rejects on its
-   * timeout, and a timer left running past the test fires after the environment
-   * is torn down, where the globals it touches no longer exist.
-   */
-  const settleHydration = async (client: AuthClient): Promise<void> => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-    await client.getIdentity();
-  };
-
   /** Seeds the cross-origin expiration hint the way another origin would. */
   const setExpirationCookie = (value: string): void => {
     // biome-ignore lint/suspicious/noDocumentCookie: seeding the store the client reads synchronously.
@@ -836,11 +828,14 @@ describe('AuthClient shared session', () => {
     expect(client.isAuthenticated()).toBe(true);
   });
 
-  it('stores the session in the hub when sharedSessionHub is set', async () => {
+  it('stores the session in a shared session hub', async () => {
     // Long enough that the frame is still attached when the assertions run: a
     // failed handshake removes it.
     const client = new AuthClient({
-      sharedSessionHub: { url: 'https://auth.example.com/hub.html', timeout: 300 },
+      storage: new SharedSessionStorage({
+        hub: { url: 'https://auth.example.com/hub.html', timeout: 300 },
+        derivationOrigin: 'https://auth.example.com',
+      }),
       derivationOrigin: 'https://auth.example.com',
       idleOptions: { disableIdle: true },
     });
@@ -853,80 +848,28 @@ describe('AuthClient shared session', () => {
     expect(frame.src).toBe('https://auth.example.com/hub.html');
     expect(frame.hidden).toBe(true);
 
-    // The hub never answers here, so hydration falls back to anonymous.
+    // The hub never answers, so hydration ends in the anonymous fallback.
+    // Awaiting it also settles the handshake timeout: a timer left running past
+    // the test fires after the environment is torn down, where the globals its
+    // cleanup touches no longer exist.
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const identity = await client.getIdentity();
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
   });
 
-  it('ignores a storage passed alongside sharedSessionHub', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const storage = fakeStore();
-
-    const client = new AuthClient({
-      sharedSessionHub: { url: 'https://auth.example.com/hub.html', timeout: 30 },
-      derivationOrigin: 'https://auth.example.com',
-      // Only reachable from JavaScript: the types make these mutually exclusive.
-      storage,
-      idleOptions: { disableIdle: true },
-    } as never);
-
-    expect(warn.mock.calls[0][0]).toContain('`storage` is ignored');
-    expect(storage.get).not.toHaveBeenCalled();
-    await settleHydration(client);
-  });
-
-  it('reads the expiration from a cookie when a shared session hub is set', async () => {
-    // Host-only so it sticks on jsdom's localhost origin, which is also the
-    // derivation origin here.
+  it('reads the expiration from a cookie shared by the sharing origins', () => {
     setExpirationCookie(futureExpirationNs());
     expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
 
     const client = new AuthClient({
-      sharedSessionHub: { url: 'http://localhost:4000/hub.html', timeout: 30 },
-      derivationOrigin: 'http://localhost:3000',
+      syncStorage: new SyncCookieStorage({ domain: 'localhost' }),
       idleOptions: { disableIdle: true },
     });
 
     expect(client.isAuthenticated()).toBe(true);
-    await settleHydration(client);
   });
 
-  it('scopes the cookie to the hub, not the derivation origin', async () => {
-    // The hub is at-or-above this origin while the derivation origin is an
-    // unrelated domain, so only following the hub reaches a usable cookie.
-    setExpirationCookie(futureExpirationNs());
-    const client = new AuthClient({
-      sharedSessionHub: { url: 'http://localhost:4000/hub.html', timeout: 30 },
-      derivationOrigin: 'https://example2.com',
-      idleOptions: { disableIdle: true },
-    });
-
-    expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
-    expect(client.isAuthenticated()).toBe(true);
-    await settleHydration(client);
-  });
-
-  it('falls back to localStorage when the hub is on a sibling domain', async () => {
-    // A cookie for auth.localhost cannot be written from jsdom's localhost
-    // origin, so a cookie-backed store would never read back what it wrote.
-    const client = new AuthClient({
-      sharedSessionHub: { url: 'http://auth.localhost:4000/hub.html', timeout: 30 },
-      derivationOrigin: 'http://auth.localhost:4000',
-      idleOptions: { disableIdle: true },
-    });
-
-    // A cookie is unreachable here, so localStorage is what it reads.
-    localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
-    expect(client.isAuthenticated()).toBe(true);
-
-    localStorage.clear();
-    setExpirationCookie(futureExpirationNs());
-    expect(client.isAuthenticated()).toBe(false);
-    await settleHydration(client);
-  });
-
-  it('ignores that cookie without a shared session hub', () => {
+  it('ignores that cookie with the default sync storage', () => {
     setExpirationCookie(futureExpirationNs());
 
     const client = new AuthClient({ idleOptions: { disableIdle: true } });

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -756,6 +756,29 @@ describe('AuthClient shared session', () => {
   const futureExpirationNs = () =>
     ((BigInt(Date.now()) + BigInt(3_600_000)) * BigInt(1_000_000)).toString();
 
+  beforeEach(() => {
+    // The global stub drops hostname/protocol, which decide where the
+    // expiration is kept.
+    vi.stubGlobal('location', {
+      reload: vi.fn(),
+      hostname: 'localhost',
+      protocol: 'http:',
+      origin: 'http://localhost:3000',
+    });
+  });
+
+  /** Seeds the cross-origin expiration hint the way another origin would. */
+  const setExpirationCookie = (value: string): void => {
+    // biome-ignore lint/suspicious/noDocumentCookie: seeding the store the client reads synchronously.
+    document.cookie = `${EXPIRATION_KEY}=${value}; Path=/`;
+  };
+
+  afterEach(() => {
+    // Cookies outlive localStorage.clear(), so a leftover expiration would make
+    // a later test look signed in.
+    setExpirationCookie('');
+  });
+
   it('caches the expiration when restoring a session this origin never signed in for', async () => {
     const key = Ed25519KeyIdentity.generate();
     const chain = await createTestDelegation(key);
@@ -840,5 +863,73 @@ describe('AuthClient shared session', () => {
 
     expect(warn.mock.calls[0][0]).toContain('`storage` is ignored');
     expect(storage.get).not.toHaveBeenCalled();
+  });
+
+  it('reads the expiration from a cookie when a shared session hub is set', async () => {
+    // Host-only so it sticks on jsdom's localhost origin, which is also the
+    // derivation origin here.
+    setExpirationCookie(futureExpirationNs());
+    expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
+
+    const client = new AuthClient({
+      sharedSessionHub: { url: 'http://localhost:4000/hub.html', timeout: 30 },
+      derivationOrigin: 'http://localhost:3000',
+      idleOptions: { disableIdle: true },
+    });
+
+    expect(client.isAuthenticated()).toBe(true);
+  });
+
+  it('falls back to localStorage when the derivation origin is a sibling domain', async () => {
+    // A cookie for auth.localhost cannot be written from jsdom's localhost
+    // origin, so a cookie-backed store would never read back what it wrote.
+    const client = new AuthClient({
+      sharedSessionHub: { url: 'http://auth.localhost:4000/hub.html', timeout: 30 },
+      derivationOrigin: 'http://auth.localhost:4000',
+      idleOptions: { disableIdle: true },
+    });
+
+    // A cookie is unreachable here, so localStorage is what it reads.
+    localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
+    expect(client.isAuthenticated()).toBe(true);
+
+    localStorage.clear();
+    setExpirationCookie(futureExpirationNs());
+    expect(client.isAuthenticated()).toBe(false);
+  });
+
+  it('ignores that cookie without a shared session hub', () => {
+    setExpirationCookie(futureExpirationNs());
+
+    const client = new AuthClient({ idleOptions: { disableIdle: true } });
+
+    expect(client.isAuthenticated()).toBe(false);
+  });
+
+  it('prefers an explicitly provided sync storage', () => {
+    const syncStorage = {
+      get: vi.fn().mockReturnValue(futureExpirationNs()),
+      set: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const client = new AuthClient({ syncStorage, idleOptions: { disableIdle: true } });
+
+    expect(client.isAuthenticated()).toBe(true);
+    expect(syncStorage.get).toHaveBeenCalledWith(EXPIRATION_KEY);
+  });
+
+  it('treats an unparseable expiration as no session', () => {
+    // Any subdomain can write the cookie, so the value may be anything.
+    const syncStorage = {
+      get: vi.fn().mockReturnValue('not-a-number'),
+      set: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const client = new AuthClient({ syncStorage, idleOptions: { disableIdle: true } });
+
+    expect(() => client.isAuthenticated()).not.toThrow();
+    expect(client.isAuthenticated()).toBe(false);
   });
 });

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -738,3 +738,107 @@ describe('AuthClient signIn + requestAttributes', () => {
     expect(identity.getPrincipal().isAnonymous()).toBe(false);
   });
 });
+
+describe('AuthClient shared session', () => {
+  // Not exported by the module under test; asserted through isAuthenticated().
+  const EXPIRATION_KEY = 'ic-delegation_expiration';
+
+  const fakeStore = (entries: Record<string, string> = {}): AuthClientStorage => ({
+    get: vi.fn(async (key) => entries[key] ?? null),
+    set: vi.fn(async (key, value) => {
+      entries[key] = value as string;
+    }),
+    remove: vi.fn(async (key) => {
+      delete entries[key];
+    }),
+  });
+
+  const futureExpirationNs = () =>
+    ((BigInt(Date.now()) + BigInt(3_600_000)) * BigInt(1_000_000)).toString();
+
+  it('caches the expiration when restoring a session this origin never signed in for', async () => {
+    const key = Ed25519KeyIdentity.generate();
+    const chain = await createTestDelegation(key);
+    const storage = fakeStore({
+      [KEY_STORAGE_KEY]: JSON.stringify(key.toJSON()),
+      [KEY_STORAGE_DELEGATION]: JSON.stringify(chain.toJSON()),
+    });
+
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    // Nothing cached yet: this origin has no sign-in of its own to have written it.
+    expect(client.isAuthenticated()).toBe(false);
+
+    const identity = await client.getIdentity();
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(false);
+    expect(client.isAuthenticated()).toBe(true);
+  });
+
+  it('clears a stale expiration when the session is no longer in the store', async () => {
+    // Another origin signed out, which cannot reach this origin's localStorage.
+    localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
+    const client = new AuthClient({ storage: fakeStore(), idleOptions: { disableIdle: true } });
+    expect(client.isAuthenticated()).toBe(true);
+
+    await client.getIdentity();
+
+    expect(client.isAuthenticated()).toBe(false);
+  });
+
+  it('stays anonymous and keeps the cached expiration when the store is unreachable', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    localStorage.setItem(EXPIRATION_KEY, futureExpirationNs());
+    const storage: AuthClientStorage = {
+      get: vi.fn().mockRejectedValue(new Error('hub unreachable')),
+      set: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    const client = new AuthClient({ storage, idleOptions: { disableIdle: true } });
+    const identity = await client.getIdentity();
+
+    expect(identity.getPrincipal().isAnonymous()).toBe(true);
+    expect(error.mock.calls[0][0]).toContain('Failed to restore the session');
+    // A hub that failed to answer has not said the session is gone.
+    expect(client.isAuthenticated()).toBe(true);
+  });
+
+  it('stores the session in the hub when sharedSessionHub is set', async () => {
+    // Long enough that the frame is still attached when the assertions run: a
+    // failed handshake removes it.
+    const client = new AuthClient({
+      sharedSessionHub: { url: 'https://auth.example.com/hub.html', timeout: 300 },
+      derivationOrigin: 'https://auth.example.com',
+      idleOptions: { disableIdle: true },
+    });
+
+    const frame = await vi.waitFor(() => {
+      const found = document.querySelector('iframe');
+      expect(found).not.toBeNull();
+      return found as HTMLIFrameElement;
+    });
+    expect(frame.src).toBe('https://auth.example.com/hub.html');
+    expect(frame.hidden).toBe(true);
+
+    // The hub never answers here, so hydration falls back to anonymous.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const identity = await client.getIdentity();
+    expect(identity.getPrincipal().isAnonymous()).toBe(true);
+  });
+
+  it('ignores a storage passed alongside sharedSessionHub', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const storage = fakeStore();
+
+    new AuthClient({
+      sharedSessionHub: { url: 'https://auth.example.com/hub.html', timeout: 30 },
+      derivationOrigin: 'https://auth.example.com',
+      // Only reachable from JavaScript: the types make these mutually exclusive.
+      storage,
+      idleOptions: { disableIdle: true },
+    } as never);
+
+    expect(warn.mock.calls[0][0]).toContain('`storage` is ignored');
+    expect(storage.get).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -767,6 +767,16 @@ describe('AuthClient shared session', () => {
     });
   });
 
+  /**
+   * Waits for hydration to finish. A hub that never answers rejects on its
+   * timeout, and a timer left running past the test fires after the environment
+   * is torn down, where the globals it touches no longer exist.
+   */
+  const settleHydration = async (client: AuthClient): Promise<void> => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await client.getIdentity();
+  };
+
   /** Seeds the cross-origin expiration hint the way another origin would. */
   const setExpirationCookie = (value: string): void => {
     // biome-ignore lint/suspicious/noDocumentCookie: seeding the store the client reads synchronously.
@@ -849,11 +859,11 @@ describe('AuthClient shared session', () => {
     expect(identity.getPrincipal().isAnonymous()).toBe(true);
   });
 
-  it('ignores a storage passed alongside sharedSessionHub', () => {
+  it('ignores a storage passed alongside sharedSessionHub', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const storage = fakeStore();
 
-    new AuthClient({
+    const client = new AuthClient({
       sharedSessionHub: { url: 'https://auth.example.com/hub.html', timeout: 30 },
       derivationOrigin: 'https://auth.example.com',
       // Only reachable from JavaScript: the types make these mutually exclusive.
@@ -863,6 +873,7 @@ describe('AuthClient shared session', () => {
 
     expect(warn.mock.calls[0][0]).toContain('`storage` is ignored');
     expect(storage.get).not.toHaveBeenCalled();
+    await settleHydration(client);
   });
 
   it('reads the expiration from a cookie when a shared session hub is set', async () => {
@@ -878,6 +889,7 @@ describe('AuthClient shared session', () => {
     });
 
     expect(client.isAuthenticated()).toBe(true);
+    await settleHydration(client);
   });
 
   it('falls back to localStorage when the derivation origin is a sibling domain', async () => {
@@ -896,6 +908,7 @@ describe('AuthClient shared session', () => {
     localStorage.clear();
     setExpirationCookie(futureExpirationNs());
     expect(client.isAuthenticated()).toBe(false);
+    await settleHydration(client);
   });
 
   it('ignores that cookie without a shared session hub', () => {

--- a/tests/client/auth-client.test.ts
+++ b/tests/client/auth-client.test.ts
@@ -769,10 +769,13 @@ describe('AuthClient shared session', () => {
     });
   });
 
-  /** Seeds the cross-origin expiration hint the way another origin would. */
+  /**
+   * Seeds the cross-origin expiration hint the way another origin would. The
+   * name carries the derivation origin, so it must match what the store builds.
+   */
   const setExpirationCookie = (value: string): void => {
     // biome-ignore lint/suspicious/noDocumentCookie: seeding the store the client reads synchronously.
-    document.cookie = `${EXPIRATION_KEY}=${value}; Path=/`;
+    document.cookie = `${EXPIRATION_KEY}.https___example.com=${value}; Path=/`;
   };
 
   afterEach(() => {
@@ -833,8 +836,9 @@ describe('AuthClient shared session', () => {
     // failed handshake removes it.
     const client = new AuthClient({
       storage: new SharedSessionStorage({
-        hub: { url: 'https://auth.example.com/hub.html', timeout: 300 },
+        url: 'https://auth.example.com/shared-session.html',
         derivationOrigin: 'https://auth.example.com',
+        timeout: 300,
       }),
       derivationOrigin: 'https://auth.example.com',
       idleOptions: { disableIdle: true },
@@ -845,7 +849,7 @@ describe('AuthClient shared session', () => {
       expect(found).not.toBeNull();
       return found as HTMLIFrameElement;
     });
-    expect(frame.src).toBe('https://auth.example.com/hub.html');
+    expect(frame.src).toBe('https://auth.example.com/shared-session.html');
     expect(frame.hidden).toBe(true);
 
     // The hub never answers, so hydration ends in the anonymous fallback.
@@ -862,7 +866,10 @@ describe('AuthClient shared session', () => {
     expect(localStorage.getItem(EXPIRATION_KEY)).toBeNull();
 
     const client = new AuthClient({
-      syncStorage: new SyncCookieStorage({ domain: 'localhost' }),
+      syncStorage: new SyncCookieStorage({
+        domain: 'localhost',
+        derivationOrigin: 'https://example.com',
+      }),
       idleOptions: { disableIdle: true },
     });
 

--- a/tests/client/sync-storage.test.ts
+++ b/tests/client/sync-storage.test.ts
@@ -132,7 +132,7 @@ describe('SyncCookieStorage', () => {
     expect(attributesOf(writes[0])).toContain('Secure');
   });
 
-  it('omits Secure on loopback, which Safari rejects over http', () => {
+  it('omits Secure on loopback, where it is not reliably accepted', () => {
     const writes = captureCookieWrites();
     testStorage().set(KEY, '123');
 

--- a/tests/client/sync-storage.test.ts
+++ b/tests/client/sync-storage.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SyncCookieStorage, SyncLocalStorage } from '../../src/client/sync-storage.ts';
+
+const KEY = 'ic-delegation_expiration';
+
+/**
+ * Records what is assigned to `document.cookie` while still applying it.
+ *
+ * The attributes are the security-relevant part and cannot be read back:
+ * `document.cookie` returns names and values only.
+ */
+function captureCookieWrites(): string[] {
+  const writes: string[] = [];
+  const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(document), 'cookie');
+  if (descriptor?.get === undefined || descriptor.set === undefined) {
+    throw new Error('document.cookie is not an accessor');
+  }
+  Object.defineProperty(document, 'cookie', {
+    configurable: true,
+    get: () => descriptor.get?.call(document),
+    set: (value: string) => {
+      writes.push(value);
+      descriptor.set?.call(document, value);
+    },
+  });
+  return writes;
+}
+
+const attributesOf = (write: string) => write.split('; ').slice(1);
+
+/** Writes a cookie without going through the class under test. */
+function setRawCookie(value: string): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: these tests exercise the document.cookie store itself.
+  document.cookie = value;
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  // Drop the capture override, if the test installed one.
+  delete (document as unknown as { cookie?: unknown }).cookie;
+  for (const entry of document.cookie.split(';')) {
+    const name = entry.split('=')[0]?.trim();
+    if (name) setRawCookie(`${name}=; Path=/; Max-Age=0`);
+  }
+});
+
+describe('SyncLocalStorage', () => {
+  it('round-trips a value', () => {
+    const storage = new SyncLocalStorage();
+    expect(storage.get(KEY)).toBeNull();
+
+    storage.set(KEY, '123');
+    expect(storage.get(KEY)).toBe('123');
+    expect(localStorage.getItem(KEY)).toBe('123');
+
+    storage.remove(KEY);
+    expect(storage.get(KEY)).toBeNull();
+  });
+
+  it('keeps a value whose expiry has passed, having no way to expire it', () => {
+    const storage = new SyncLocalStorage();
+    storage.set(KEY, '123', Date.now() - 1_000);
+    expect(storage.get(KEY)).toBe('123');
+  });
+});
+
+describe('SyncCookieStorage', () => {
+  // jsdom serves the tests from localhost, so only a matching domain sticks.
+  const testStorage = () => new SyncCookieStorage({ domain: 'localhost' });
+
+  it('round-trips a value', () => {
+    const storage = testStorage();
+    expect(storage.get(KEY)).toBeNull();
+
+    storage.set(KEY, '123');
+    expect(storage.get(KEY)).toBe('123');
+
+    storage.remove(KEY);
+    expect(storage.get(KEY)).toBeNull();
+  });
+
+  it('reads its own value among other cookies', () => {
+    setRawCookie('other=first; Path=/');
+    setRawCookie('another=second; Path=/');
+    const storage = testStorage();
+    storage.set(KEY, '123');
+
+    expect(storage.get(KEY)).toBe('123');
+    expect(storage.get('other')).toBe('first');
+    expect(storage.get('missing')).toBeNull();
+  });
+
+  it('expires with the value it describes', () => {
+    const writes = captureCookieWrites();
+    testStorage().set(KEY, '123', Date.now() + 60_000);
+
+    expect(attributesOf(writes[0])).toContain('Max-Age=60');
+  });
+
+  it('removes rather than writes a value whose expiry has passed', () => {
+    const storage = testStorage();
+    storage.set(KEY, '123');
+    storage.set(KEY, '456', Date.now() - 1_000);
+
+    expect(storage.get(KEY)).toBeNull();
+  });
+
+  it('omits Domain on loopback, where a host-only cookie already spans ports', () => {
+    const writes = captureCookieWrites();
+    testStorage().set(KEY, '123');
+
+    expect(writes[0]).not.toContain('Domain=');
+    expect(attributesOf(writes[0])).toEqual(expect.arrayContaining(['Path=/', 'SameSite=Lax']));
+  });
+
+  it('scopes the cookie to the domain so subdomains share it', () => {
+    const writes = captureCookieWrites();
+    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
+
+    expect(attributesOf(writes[0])).toContain('Domain=example.com');
+  });
+
+  it('marks the cookie Secure over https', () => {
+    vi.stubGlobal('location', { protocol: 'https:' });
+    const writes = captureCookieWrites();
+    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
+
+    expect(attributesOf(writes[0])).toContain('Secure');
+  });
+
+  it('omits Secure on loopback, which Safari rejects over http', () => {
+    const writes = captureCookieWrites();
+    testStorage().set(KEY, '123');
+
+    expect(attributesOf(writes[0])).not.toContain('Secure');
+  });
+
+  it('removes with the same attributes, so the write targets the same cookie', () => {
+    const writes = captureCookieWrites();
+    const storage = new SyncCookieStorage({ domain: 'example.com' });
+    storage.set(KEY, '123');
+    storage.remove(KEY);
+
+    expect(attributesOf(writes[1])).toEqual(
+      expect.arrayContaining(['Domain=example.com', 'Path=/', 'Max-Age=0']),
+    );
+  });
+});

--- a/tests/client/sync-storage.test.ts
+++ b/tests/client/sync-storage.test.ts
@@ -139,6 +139,31 @@ describe('SyncCookieStorage', () => {
     expect(attributesOf(writes[0])).not.toContain('Secure');
   });
 
+  it('keeps two shared sessions under one domain apart', () => {
+    const first = new SyncCookieStorage({ domain: 'localhost', namespace: 'auth.example.com' });
+    const second = new SyncCookieStorage({ domain: 'localhost', namespace: 'other.example.com' });
+
+    first.set(KEY, '111');
+    second.set(KEY, '222');
+
+    expect(first.get(KEY)).toBe('111');
+    expect(second.get(KEY)).toBe('222');
+
+    first.remove(KEY);
+    expect(first.get(KEY)).toBeNull();
+    expect(second.get(KEY)).toBe('222');
+  });
+
+  it('replaces characters a cookie name cannot carry', () => {
+    const writes = captureCookieWrites();
+    new SyncCookieStorage({ domain: 'localhost', namespace: 'http://localhost:4000' }).set(
+      KEY,
+      '123',
+    );
+
+    expect(writes[0].split('=')[0]).toBe(`${KEY}.http___localhost_4000`);
+  });
+
   it('removes with the same attributes, so the write targets the same cookie', () => {
     const writes = captureCookieWrites();
     const storage = new SyncCookieStorage({ domain: 'example.com' });
@@ -148,5 +173,21 @@ describe('SyncCookieStorage', () => {
     expect(attributesOf(writes[1])).toEqual(
       expect.arrayContaining(['Domain=example.com', 'Path=/', 'Max-Age=0']),
     );
+  });
+});
+
+describe('SyncCookieStorage namespace', () => {
+  it('names the same cookie for a hub url and its origin', () => {
+    const fromUrl = new SyncCookieStorage({
+      domain: 'localhost',
+      namespace: 'https://auth.example.com/hub.html',
+    });
+    const fromOrigin = new SyncCookieStorage({
+      domain: 'localhost',
+      namespace: 'https://auth.example.com',
+    });
+
+    fromUrl.set(KEY, '123');
+    expect(fromOrigin.get(KEY)).toBe('123');
   });
 });

--- a/tests/client/sync-storage.test.ts
+++ b/tests/client/sync-storage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SyncCookieStorage, SyncLocalStorage } from '../../src/client/sync-storage.ts';
 
 const KEY = 'ic-delegation_expiration';
+const DERIVATION_ORIGIN = 'https://example.com';
 
 /**
  * Records what is assigned to `document.cookie` while still applying it.
@@ -70,7 +71,8 @@ describe('SyncLocalStorage', () => {
 
 describe('SyncCookieStorage', () => {
   // jsdom serves the tests from localhost, so only a matching domain sticks.
-  const testStorage = () => new SyncCookieStorage({ domain: 'localhost' });
+  const testStorage = () =>
+    new SyncCookieStorage({ domain: 'localhost', derivationOrigin: DERIVATION_ORIGIN });
 
   it('round-trips a value', () => {
     const storage = testStorage();
@@ -85,12 +87,13 @@ describe('SyncCookieStorage', () => {
 
   it('reads its own value among other cookies', () => {
     setRawCookie('other=first; Path=/');
-    setRawCookie('another=second; Path=/');
+    // A bare key belongs to no session and must not be mistaken for this one's.
+    setRawCookie(`${KEY}=unnamespaced; Path=/`);
     const storage = testStorage();
     storage.set(KEY, '123');
 
     expect(storage.get(KEY)).toBe('123');
-    expect(storage.get('other')).toBe('first');
+    expect(storage.get('other')).toBeNull();
     expect(storage.get('missing')).toBeNull();
   });
 
@@ -119,7 +122,10 @@ describe('SyncCookieStorage', () => {
 
   it('scopes the cookie to the domain so subdomains share it', () => {
     const writes = captureCookieWrites();
-    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
+    new SyncCookieStorage({ domain: 'example.com', derivationOrigin: DERIVATION_ORIGIN }).set(
+      KEY,
+      '123',
+    );
 
     expect(attributesOf(writes[0])).toContain('Domain=example.com');
   });
@@ -127,7 +133,10 @@ describe('SyncCookieStorage', () => {
   it('marks the cookie Secure over https', () => {
     vi.stubGlobal('location', { protocol: 'https:' });
     const writes = captureCookieWrites();
-    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
+    new SyncCookieStorage({ domain: 'example.com', derivationOrigin: DERIVATION_ORIGIN }).set(
+      KEY,
+      '123',
+    );
 
     expect(attributesOf(writes[0])).toContain('Secure');
   });
@@ -140,8 +149,14 @@ describe('SyncCookieStorage', () => {
   });
 
   it('keeps two shared sessions under one domain apart', () => {
-    const first = new SyncCookieStorage({ domain: 'localhost', namespace: 'auth.example.com' });
-    const second = new SyncCookieStorage({ domain: 'localhost', namespace: 'other.example.com' });
+    const first = new SyncCookieStorage({
+      domain: 'localhost',
+      derivationOrigin: 'https://one.example.com',
+    });
+    const second = new SyncCookieStorage({
+      domain: 'localhost',
+      derivationOrigin: 'https://two.example.com',
+    });
 
     first.set(KEY, '111');
     second.set(KEY, '222');
@@ -156,17 +171,20 @@ describe('SyncCookieStorage', () => {
 
   it('replaces characters a cookie name cannot carry', () => {
     const writes = captureCookieWrites();
-    new SyncCookieStorage({ domain: 'localhost', namespace: 'http://localhost:4000' }).set(
-      KEY,
-      '123',
-    );
+    new SyncCookieStorage({
+      domain: 'localhost',
+      derivationOrigin: 'http://localhost:4000',
+    }).set(KEY, '123');
 
     expect(writes[0].split('=')[0]).toBe(`${KEY}.http___localhost_4000`);
   });
 
   it('removes with the same attributes, so the write targets the same cookie', () => {
     const writes = captureCookieWrites();
-    const storage = new SyncCookieStorage({ domain: 'example.com' });
+    const storage = new SyncCookieStorage({
+      domain: 'example.com',
+      derivationOrigin: DERIVATION_ORIGIN,
+    });
     storage.set(KEY, '123');
     storage.remove(KEY);
 
@@ -176,18 +194,18 @@ describe('SyncCookieStorage', () => {
   });
 });
 
-describe('SyncCookieStorage namespace', () => {
-  it('names the same cookie for a hub url and its origin', () => {
-    const fromUrl = new SyncCookieStorage({
+describe('SyncCookieStorage derivation origin', () => {
+  it('names the same cookie however the origin is written', () => {
+    const withPath = new SyncCookieStorage({
       domain: 'localhost',
-      namespace: 'https://auth.example.com/hub.html',
+      derivationOrigin: 'https://example.com/',
     });
-    const fromOrigin = new SyncCookieStorage({
+    const bare = new SyncCookieStorage({
       domain: 'localhost',
-      namespace: 'https://auth.example.com',
+      derivationOrigin: new URL('https://example.com'),
     });
 
-    fromUrl.set(KEY, '123');
-    expect(fromOrigin.get(KEY)).toBe('123');
+    withPath.set(KEY, '123');
+    expect(bare.get(KEY)).toBe('123');
   });
 });

--- a/tests/client/sync-storage.test.ts
+++ b/tests/client/sync-storage.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SyncCookieStorage, SyncLocalStorage } from '../../src/client/sync-storage.ts';
 
 const KEY = 'ic-delegation_expiration';
-const DERIVATION_ORIGIN = 'https://example.com';
 
 /**
  * Records what is assigned to `document.cookie` while still applying it.
@@ -71,8 +70,7 @@ describe('SyncLocalStorage', () => {
 
 describe('SyncCookieStorage', () => {
   // jsdom serves the tests from localhost, so only a matching domain sticks.
-  const testStorage = () =>
-    new SyncCookieStorage({ domain: 'localhost', derivationOrigin: DERIVATION_ORIGIN });
+  const testStorage = () => new SyncCookieStorage({ domain: 'localhost' });
 
   it('round-trips a value', () => {
     const storage = testStorage();
@@ -87,13 +85,12 @@ describe('SyncCookieStorage', () => {
 
   it('reads its own value among other cookies', () => {
     setRawCookie('other=first; Path=/');
-    // A bare key belongs to no session and must not be mistaken for this one's.
-    setRawCookie(`${KEY}=unnamespaced; Path=/`);
+    setRawCookie('another=second; Path=/');
     const storage = testStorage();
     storage.set(KEY, '123');
 
     expect(storage.get(KEY)).toBe('123');
-    expect(storage.get('other')).toBeNull();
+    expect(storage.get('other')).toBe('first');
     expect(storage.get('missing')).toBeNull();
   });
 
@@ -122,10 +119,7 @@ describe('SyncCookieStorage', () => {
 
   it('scopes the cookie to the domain so subdomains share it', () => {
     const writes = captureCookieWrites();
-    new SyncCookieStorage({ domain: 'example.com', derivationOrigin: DERIVATION_ORIGIN }).set(
-      KEY,
-      '123',
-    );
+    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
 
     expect(attributesOf(writes[0])).toContain('Domain=example.com');
   });
@@ -133,10 +127,7 @@ describe('SyncCookieStorage', () => {
   it('marks the cookie Secure over https', () => {
     vi.stubGlobal('location', { protocol: 'https:' });
     const writes = captureCookieWrites();
-    new SyncCookieStorage({ domain: 'example.com', derivationOrigin: DERIVATION_ORIGIN }).set(
-      KEY,
-      '123',
-    );
+    new SyncCookieStorage({ domain: 'example.com' }).set(KEY, '123');
 
     expect(attributesOf(writes[0])).toContain('Secure');
   });
@@ -148,64 +139,14 @@ describe('SyncCookieStorage', () => {
     expect(attributesOf(writes[0])).not.toContain('Secure');
   });
 
-  it('keeps two shared sessions under one domain apart', () => {
-    const first = new SyncCookieStorage({
-      domain: 'localhost',
-      derivationOrigin: 'https://one.example.com',
-    });
-    const second = new SyncCookieStorage({
-      domain: 'localhost',
-      derivationOrigin: 'https://two.example.com',
-    });
-
-    first.set(KEY, '111');
-    second.set(KEY, '222');
-
-    expect(first.get(KEY)).toBe('111');
-    expect(second.get(KEY)).toBe('222');
-
-    first.remove(KEY);
-    expect(first.get(KEY)).toBeNull();
-    expect(second.get(KEY)).toBe('222');
-  });
-
-  it('replaces characters a cookie name cannot carry', () => {
-    const writes = captureCookieWrites();
-    new SyncCookieStorage({
-      domain: 'localhost',
-      derivationOrigin: 'http://localhost:4000',
-    }).set(KEY, '123');
-
-    expect(writes[0].split('=')[0]).toBe(`${KEY}.http___localhost_4000`);
-  });
-
   it('removes with the same attributes, so the write targets the same cookie', () => {
     const writes = captureCookieWrites();
-    const storage = new SyncCookieStorage({
-      domain: 'example.com',
-      derivationOrigin: DERIVATION_ORIGIN,
-    });
+    const storage = new SyncCookieStorage({ domain: 'example.com' });
     storage.set(KEY, '123');
     storage.remove(KEY);
 
     expect(attributesOf(writes[1])).toEqual(
       expect.arrayContaining(['Domain=example.com', 'Path=/', 'Max-Age=0']),
     );
-  });
-});
-
-describe('SyncCookieStorage derivation origin', () => {
-  it('names the same cookie however the origin is written', () => {
-    const withPath = new SyncCookieStorage({
-      domain: 'localhost',
-      derivationOrigin: 'https://example.com/',
-    });
-    const bare = new SyncCookieStorage({
-      domain: 'localhost',
-      derivationOrigin: new URL('https://example.com'),
-    });
-
-    withPath.set(KEY, '123');
-    expect(bare.get(KEY)).toBe('123');
   });
 });

--- a/tests/shared-session/options.test-d.ts
+++ b/tests/shared-session/options.test-d.ts
@@ -4,27 +4,31 @@ import { IdbStorage } from '../../src/client/storage.ts';
 import { SyncCookieStorage, SyncLocalStorage } from '../../src/client/sync-storage.ts';
 import { SharedSessionStorage } from '../../src/shared-session/storage.ts';
 
-const HUB = { url: 'https://auth.example.com/hub.html' };
+const HUB_URL = 'https://auth.example.com/shared-session.html';
 const DERIVATION_ORIGIN = 'https://auth.example.com';
 
 describe('SharedSessionStorage options', () => {
   it('requires a derivation origin', () => {
-    new SharedSessionStorage({ hub: HUB, derivationOrigin: DERIVATION_ORIGIN });
+    new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN });
     new SharedSessionStorage({
-      hub: { ...HUB, timeout: 5_000 },
+      url: new URL(HUB_URL),
       derivationOrigin: new URL(DERIVATION_ORIGIN),
+      timeout: 5_000,
     });
     // @ts-expect-error a shared store without a shared derivation origin would
     // give each origin a different principal from the same key.
-    new SharedSessionStorage({ hub: HUB });
+    new SharedSessionStorage({ url: HUB_URL });
   });
 });
 
 describe('AuthClientCreateOptions', () => {
   it('takes a shared session as its storage', () => {
     new AuthClient({
-      storage: new SharedSessionStorage({ hub: HUB, derivationOrigin: DERIVATION_ORIGIN }),
-      syncStorage: new SyncCookieStorage({ domain: 'example.com', namespace: 'auth.example.com' }),
+      storage: new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN }),
+      syncStorage: new SyncCookieStorage({
+        domain: 'example.com',
+        derivationOrigin: DERIVATION_ORIGIN,
+      }),
       derivationOrigin: DERIVATION_ORIGIN,
     });
   });
@@ -33,6 +37,8 @@ describe('AuthClientCreateOptions', () => {
     new AuthClient();
     new AuthClient({ storage: new IdbStorage() });
     new AuthClient({ syncStorage: new SyncLocalStorage() });
+    // @ts-expect-error a cookie store must know which session it describes.
+    new SyncCookieStorage({ domain: 'example.com' });
     new AuthClient({ derivationOrigin: DERIVATION_ORIGIN });
     new AuthClient({ keyType: 'Ed25519', transport: 'redirect', openIdProvider: 'google' });
   });

--- a/tests/shared-session/options.test-d.ts
+++ b/tests/shared-session/options.test-d.ts
@@ -8,27 +8,19 @@ const HUB_URL = 'https://auth.example.com/shared-session.html';
 const DERIVATION_ORIGIN = 'https://auth.example.com';
 
 describe('SharedSessionStorage options', () => {
-  it('requires a derivation origin', () => {
-    new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN });
-    new SharedSessionStorage({
-      url: new URL(HUB_URL),
-      derivationOrigin: new URL(DERIVATION_ORIGIN),
-      timeout: 5_000,
-    });
-    // @ts-expect-error a shared store without a shared derivation origin would
-    // give each origin a different principal from the same key.
+  it('takes the hub url, and optionally a timeout', () => {
     new SharedSessionStorage({ url: HUB_URL });
+    new SharedSessionStorage({ url: new URL(HUB_URL), timeout: 5_000 });
+    // @ts-expect-error the hub's url is what identifies the shared session.
+    new SharedSessionStorage({});
   });
 });
 
 describe('AuthClientCreateOptions', () => {
   it('takes a shared session as its storage', () => {
     new AuthClient({
-      storage: new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN }),
-      syncStorage: new SyncCookieStorage({
-        domain: 'example.com',
-        derivationOrigin: DERIVATION_ORIGIN,
-      }),
+      storage: new SharedSessionStorage({ url: HUB_URL }),
+      syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
       derivationOrigin: DERIVATION_ORIGIN,
     });
   });
@@ -37,8 +29,8 @@ describe('AuthClientCreateOptions', () => {
     new AuthClient();
     new AuthClient({ storage: new IdbStorage() });
     new AuthClient({ syncStorage: new SyncLocalStorage() });
-    // @ts-expect-error a cookie store must know which session it describes.
-    new SyncCookieStorage({ domain: 'example.com' });
+    // @ts-expect-error a cookie store needs the domain to scope the cookie to.
+    new SyncCookieStorage({});
     new AuthClient({ derivationOrigin: DERIVATION_ORIGIN });
     new AuthClient({ keyType: 'Ed25519', transport: 'redirect', openIdProvider: 'google' });
   });

--- a/tests/shared-session/options.test-d.ts
+++ b/tests/shared-session/options.test-d.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'vitest';
+import { AuthClient } from '../../src/client/auth-client.ts';
+import { IdbStorage } from '../../src/client/storage.ts';
+
+const HUB = { url: 'https://auth.example.com/hub.html' };
+const DERIVATION_ORIGIN = 'https://auth.example.com';
+
+describe('AuthClientCreateOptions', () => {
+  it('accepts a hub together with a derivation origin', () => {
+    new AuthClient({ sharedSessionHub: HUB, derivationOrigin: DERIVATION_ORIGIN });
+    new AuthClient({
+      sharedSessionHub: { ...HUB, timeout: 5_000 },
+      derivationOrigin: new URL(DERIVATION_ORIGIN),
+    });
+  });
+
+  it('requires a derivation origin alongside a hub', () => {
+    // @ts-expect-error a shared session without a shared derivation origin would
+    // give each origin a different principal from the same key.
+    new AuthClient({ sharedSessionHub: HUB });
+  });
+
+  it('refuses a custom storage alongside a hub', () => {
+    new AuthClient({
+      sharedSessionHub: HUB,
+      derivationOrigin: DERIVATION_ORIGIN,
+      // @ts-expect-error the hub supplies the store.
+      storage: new IdbStorage(),
+    });
+  });
+
+  it('leaves the existing options unconstrained', () => {
+    new AuthClient();
+    new AuthClient({ storage: new IdbStorage() });
+    new AuthClient({ derivationOrigin: DERIVATION_ORIGIN });
+    new AuthClient({ storage: new IdbStorage(), derivationOrigin: DERIVATION_ORIGIN });
+    new AuthClient({ keyType: 'Ed25519', transport: 'redirect', openIdProvider: 'google' });
+  });
+});

--- a/tests/shared-session/options.test-d.ts
+++ b/tests/shared-session/options.test-d.ts
@@ -1,39 +1,39 @@
 import { describe, it } from 'vitest';
 import { AuthClient } from '../../src/client/auth-client.ts';
 import { IdbStorage } from '../../src/client/storage.ts';
+import { SyncCookieStorage, SyncLocalStorage } from '../../src/client/sync-storage.ts';
+import { SharedSessionStorage } from '../../src/shared-session/storage.ts';
 
 const HUB = { url: 'https://auth.example.com/hub.html' };
 const DERIVATION_ORIGIN = 'https://auth.example.com';
 
-describe('AuthClientCreateOptions', () => {
-  it('accepts a hub together with a derivation origin', () => {
-    new AuthClient({ sharedSessionHub: HUB, derivationOrigin: DERIVATION_ORIGIN });
-    new AuthClient({
-      sharedSessionHub: { ...HUB, timeout: 5_000 },
+describe('SharedSessionStorage options', () => {
+  it('requires a derivation origin', () => {
+    new SharedSessionStorage({ hub: HUB, derivationOrigin: DERIVATION_ORIGIN });
+    new SharedSessionStorage({
+      hub: { ...HUB, timeout: 5_000 },
       derivationOrigin: new URL(DERIVATION_ORIGIN),
     });
-  });
-
-  it('requires a derivation origin alongside a hub', () => {
-    // @ts-expect-error a shared session without a shared derivation origin would
+    // @ts-expect-error a shared store without a shared derivation origin would
     // give each origin a different principal from the same key.
-    new AuthClient({ sharedSessionHub: HUB });
+    new SharedSessionStorage({ hub: HUB });
   });
+});
 
-  it('refuses a custom storage alongside a hub', () => {
+describe('AuthClientCreateOptions', () => {
+  it('takes a shared session as its storage', () => {
     new AuthClient({
-      sharedSessionHub: HUB,
+      storage: new SharedSessionStorage({ hub: HUB, derivationOrigin: DERIVATION_ORIGIN }),
+      syncStorage: new SyncCookieStorage({ domain: 'example.com', namespace: 'auth.example.com' }),
       derivationOrigin: DERIVATION_ORIGIN,
-      // @ts-expect-error the hub supplies the store.
-      storage: new IdbStorage(),
     });
   });
 
   it('leaves the existing options unconstrained', () => {
     new AuthClient();
     new AuthClient({ storage: new IdbStorage() });
+    new AuthClient({ syncStorage: new SyncLocalStorage() });
     new AuthClient({ derivationOrigin: DERIVATION_ORIGIN });
-    new AuthClient({ storage: new IdbStorage(), derivationOrigin: DERIVATION_ORIGIN });
     new AuthClient({ keyType: 'Ed25519', transport: 'redirect', openIdProvider: 'google' });
   });
 });

--- a/tests/shared-session/serve.test.ts
+++ b/tests/shared-session/serve.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { IdbStorage } from '../../src/client/storage.ts';
+import { CHANNEL, PROTOCOL_VERSION } from '../../src/shared-session/protocol.ts';
+import { serveSharedSession } from '../../src/shared-session/serve.ts';
+
+// jsdom serves the tests from this origin, so it doubles as the hub's own origin.
+const HUB_ORIGIN = 'http://localhost:3000';
+const DERIVATION_ORIGIN = 'https://example.com';
+const CLIENT_ORIGIN = 'https://a.example.com';
+const CANISTER_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
+
+let stop: (() => void) | undefined;
+let counter = 0;
+
+const testStorage = () => {
+  counter += 1;
+  return new IdbStorage({ dbName: `serve-db-${counter}`, storeName: `serve-store-${counter}` });
+};
+
+/** Stands in for the client window the hub replies to. */
+function fakeClient(): { postMessage: Mock } {
+  return { postMessage: vi.fn() };
+}
+
+function request(
+  client: { postMessage: Mock },
+  overrides: Record<string, unknown> = {},
+  origin = CLIENT_ORIGIN,
+) {
+  const event = new MessageEvent('message', {
+    origin,
+    data: {
+      v: PROTOCOL_VERSION,
+      type: CHANNEL,
+      id: 1,
+      op: 'get',
+      key: 'identity',
+      derivationOrigin: DERIVATION_ORIGIN,
+      ...overrides,
+    },
+  });
+  // `source` is a prototype accessor, so it can only be supplied this way.
+  Object.defineProperty(event, 'source', { value: client });
+  window.dispatchEvent(event);
+}
+
+/** Resolves once the hub has answered, which it does asynchronously. */
+async function reply(client: { postMessage: Mock }) {
+  await vi.waitFor(() => expect(client.postMessage).toHaveBeenCalled());
+  return client.postMessage.mock.calls[0][0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+});
+
+describe('serveSharedSession', () => {
+  it('serves an origin listed in the alternative origins record', async () => {
+    const storage = testStorage();
+    await storage.set('identity', 'stored-key');
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage,
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client);
+
+    expect(await reply(client)).toEqual({
+      v: PROTOCOL_VERSION,
+      type: CHANNEL,
+      id: 1,
+      result: 'stored-key',
+    });
+    expect(client.postMessage).toHaveBeenCalledWith(expect.anything(), CLIENT_ORIGIN);
+  });
+
+  it('round-trips set, get and remove', async () => {
+    const storage = testStorage();
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage,
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const writer = fakeClient();
+    request(writer, { op: 'set', value: 'written' });
+    await reply(writer);
+    expect(await storage.get('identity')).toBe('written');
+
+    const remover = fakeClient();
+    request(remover, { op: 'remove', id: 2 });
+    await reply(remover);
+    expect(await storage.get('identity')).toBeNull();
+  });
+
+  it('serves the derivation origin, which its own record does not list', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [],
+    });
+
+    const client = fakeClient();
+    request(client, {}, DERIVATION_ORIGIN);
+
+    expect(await reply(client)).not.toHaveProperty('error');
+  });
+
+  it('denies an origin the record does not list', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client, {}, 'https://evil.example.com');
+
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+
+  it.each([
+    ['a path', `${CLIENT_ORIGIN}/callback`],
+    ['a trailing slash', `${CLIENT_ORIGIN}/`],
+    ['credentials', 'https://user:pass@a.example.com'],
+    ['plain http', 'http://a.example.com'],
+    ['a non-string entry', 42 as unknown as string],
+  ])('ignores a record entry carrying %s', async (_label, entry) => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [entry],
+    });
+
+    const client = fakeClient();
+    request(client);
+
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+
+  it('denies a client speaking a different protocol version', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client, { v: PROTOCOL_VERSION + 1 });
+
+    expect((await reply(client)).error).toContain('unsupported protocol version');
+  });
+
+  it('denies a client configured with a different derivation origin', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client, { derivationOrigin: 'https://other.example.com' });
+
+    expect((await reply(client)).error).toContain('derivation origin mismatch');
+  });
+
+  it('denies an unknown operation', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client, { op: 'clear' });
+
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+
+  it('ignores a message without an id, which is not a request', async () => {
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    const client = fakeClient();
+    request(client, { id: undefined, ready: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(client.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when discovery fails, and retries on the next request', async () => {
+    const allowedOrigins = vi
+      .fn<() => Promise<string[]>>()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue([CLIENT_ORIGIN]);
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins,
+    });
+
+    const denied = fakeClient();
+    request(denied);
+    expect(await reply(denied)).toMatchObject({ error: 'denied' });
+
+    const allowed = fakeClient();
+    request(allowed, { id: 2 });
+    expect(await reply(allowed)).not.toHaveProperty('error');
+    expect(allowedOrigins).toHaveBeenCalledTimes(2);
+  });
+
+  it('announces itself to the embedder and stops serving when disposed', async () => {
+    const announce = vi.spyOn(window.parent, 'postMessage');
+    const dispose = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      storage: testStorage(),
+      allowedOrigins: async () => [CLIENT_ORIGIN],
+    });
+
+    expect(announce).toHaveBeenCalledWith({ v: PROTOCOL_VERSION, type: CHANNEL, ready: true }, '*');
+
+    dispose();
+    const client = fakeClient();
+    request(client);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(client.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects a canister id that is not a principal', () => {
+    expect(() =>
+      serveSharedSession({
+        derivationOrigin: DERIVATION_ORIGIN,
+        canisterId: 'not-a-principal',
+        storage: testStorage(),
+      }),
+    ).toThrow('not a valid principal');
+  });
+});
+
+describe('serveSharedSession allow-list discovery', () => {
+  const record = (alternativeOrigins: unknown) =>
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ alternativeOrigins }),
+    });
+
+  it('reads the record through the gateway when a canister id is given', async () => {
+    const fetchMock = record([CLIENT_ORIGIN]);
+    vi.stubGlobal('fetch', fetchMock);
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      canisterId: CANISTER_ID,
+      storage: testStorage(),
+    });
+
+    const client = fakeClient();
+    request(client);
+    await reply(client);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://${CANISTER_ID}.icp0.io/.well-known/ii-alternative-origins`,
+      expect.objectContaining({ redirect: 'error', credentials: 'omit' }),
+    );
+  });
+
+  it('reads the record same-origin when it owns the derivation origin', async () => {
+    const fetchMock = record([CLIENT_ORIGIN]);
+    vi.stubGlobal('fetch', fetchMock);
+    stop = serveSharedSession({ derivationOrigin: HUB_ORIGIN, storage: testStorage() });
+
+    const client = fakeClient();
+    request(client, { derivationOrigin: HUB_ORIGIN });
+    await reply(client);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/.well-known/ii-alternative-origins',
+      expect.anything(),
+    );
+  });
+
+  it('warns when reading a remote record without certification', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', record([CLIENT_ORIGIN]));
+    stop = serveSharedSession({ derivationOrigin: DERIVATION_ORIGIN, storage: testStorage() });
+
+    const client = fakeClient();
+    request(client);
+    await reply(client);
+
+    expect(warn.mock.calls[0][0]).toContain('without certification');
+  });
+
+  it('denies everyone when the record lists more origins than II accepts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      record(Array.from({ length: 11 }, (_, i) => `https://a${i}.example.com`)),
+    );
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      canisterId: CANISTER_ID,
+      storage: testStorage(),
+    });
+
+    const client = fakeClient();
+    request(client);
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+
+  it('denies everyone when the record is malformed', async () => {
+    vi.stubGlobal('fetch', record('https://a.example.com'));
+    stop = serveSharedSession({
+      derivationOrigin: DERIVATION_ORIGIN,
+      canisterId: CANISTER_ID,
+      storage: testStorage(),
+    });
+
+    const client = fakeClient();
+    request(client);
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+});

--- a/tests/shared-session/serve.test.ts
+++ b/tests/shared-session/serve.test.ts
@@ -35,7 +35,6 @@ function request(
       id: 1,
       op: 'get',
       key: 'identity',
-      derivationOrigin: DERIVATION_ORIGIN,
       ...overrides,
     },
   });
@@ -158,19 +157,6 @@ describe('serveSharedSession', () => {
     expect((await reply(client)).error).toContain('unsupported protocol version');
   });
 
-  it('denies a client configured with a different derivation origin', async () => {
-    stop = serveSharedSession({
-      derivationOrigin: DERIVATION_ORIGIN,
-      storage: testStorage(),
-      allowedOrigins: async () => [CLIENT_ORIGIN],
-    });
-
-    const client = fakeClient();
-    request(client, { derivationOrigin: 'https://other.example.com' });
-
-    expect((await reply(client)).error).toContain('derivation origin mismatch');
-  });
-
   it('denies an unknown operation', async () => {
     stop = serveSharedSession({
       derivationOrigin: DERIVATION_ORIGIN,
@@ -280,7 +266,7 @@ describe('serveSharedSession allow-list discovery', () => {
     stop = serveSharedSession({ derivationOrigin: HUB_ORIGIN, storage: testStorage() });
 
     const client = fakeClient();
-    request(client, { derivationOrigin: HUB_ORIGIN });
+    request(client);
     await reply(client);
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/tests/shared-session/serve.test.ts
+++ b/tests/shared-session/serve.test.ts
@@ -3,10 +3,10 @@ import { IdbStorage } from '../../src/client/storage.ts';
 import { CHANNEL, PROTOCOL_VERSION } from '../../src/shared-session/protocol.ts';
 import { serveSharedSession } from '../../src/shared-session/serve.ts';
 
-// jsdom serves the tests from this origin, so it doubles as the hub's own origin.
+// jsdom serves the tests from this origin, so it stands in for the hub's own.
 const HUB_ORIGIN = 'http://localhost:3000';
-const DERIVATION_ORIGIN = 'https://example.com';
-const CLIENT_ORIGIN = 'https://a.example.com';
+const DERIVATION_ORIGIN = 'https://auth.example.com';
+const CLIENT_ORIGIN = 'https://docs.example.com';
 const CANISTER_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
 
 let stop: (() => void) | undefined;
@@ -221,16 +221,6 @@ describe('serveSharedSession', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(client.postMessage).not.toHaveBeenCalled();
   });
-
-  it('rejects a canister id that is not a principal', () => {
-    expect(() =>
-      serveSharedSession({
-        derivationOrigin: DERIVATION_ORIGIN,
-        canisterId: 'not-a-principal',
-        storage: testStorage(),
-      }),
-    ).toThrow('not a valid principal');
-  });
 });
 
 describe('serveSharedSession allow-list discovery', () => {
@@ -241,26 +231,7 @@ describe('serveSharedSession allow-list discovery', () => {
       json: async () => ({ alternativeOrigins }),
     });
 
-  it('reads the record through the gateway when a canister id is given', async () => {
-    const fetchMock = record([CLIENT_ORIGIN]);
-    vi.stubGlobal('fetch', fetchMock);
-    stop = serveSharedSession({
-      derivationOrigin: DERIVATION_ORIGIN,
-      canisterId: CANISTER_ID,
-      storage: testStorage(),
-    });
-
-    const client = fakeClient();
-    request(client);
-    await reply(client);
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      `https://${CANISTER_ID}.icp0.io/.well-known/ii-alternative-origins`,
-      expect.objectContaining({ redirect: 'error', credentials: 'omit' }),
-    );
-  });
-
-  it('reads the record same-origin when it owns the derivation origin', async () => {
+  it('reads the record same-origin when it is served from the derivation origin', async () => {
     const fetchMock = record([CLIENT_ORIGIN]);
     vi.stubGlobal('fetch', fetchMock);
     stop = serveSharedSession({ derivationOrigin: HUB_ORIGIN, storage: testStorage() });
@@ -275,16 +246,73 @@ describe('serveSharedSession allow-list discovery', () => {
     );
   });
 
-  it('warns when reading a remote record without certification', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    vi.stubGlobal('fetch', record([CLIENT_ORIGIN]));
-    stop = serveSharedSession({ derivationOrigin: DERIVATION_ORIGIN, storage: testStorage() });
+  it('reads the record through the gateway, resolving the canister from the hostname', async () => {
+    const fetchMock = record([CLIENT_ORIGIN]);
+    vi.stubGlobal('fetch', fetchMock);
+    stop = serveSharedSession({
+      derivationOrigin: `https://${CANISTER_ID}.icp0.io`,
+      storage: testStorage(),
+    });
 
     const client = fakeClient();
     request(client);
     await reply(client);
 
-    expect(warn.mock.calls[0][0]).toContain('without certification');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://${CANISTER_ID}.icp0.io/.well-known/ii-alternative-origins`,
+      expect.objectContaining({ redirect: 'error', credentials: 'omit' }),
+    );
+  });
+
+  it('asks a custom domain for its canister id, then reads through the gateway', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'HEAD') {
+        expect(url).toBe(DERIVATION_ORIGIN);
+        return { ok: true, headers: new Headers({ 'x-ic-canister-id': CANISTER_ID }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ alternativeOrigins: [CLIENT_ORIGIN] }) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    stop = serveSharedSession({ derivationOrigin: DERIVATION_ORIGIN, storage: testStorage() });
+
+    const client = fakeClient();
+    request(client);
+    expect(await reply(client)).not.toHaveProperty('error');
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      `https://${CANISTER_ID}.icp0.io/.well-known/ii-alternative-origins`,
+      expect.anything(),
+    );
+  });
+
+  it('denies everyone when a custom domain names no canister', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, headers: new Headers(), status: 200 }),
+    );
+    stop = serveSharedSession({ derivationOrigin: DERIVATION_ORIGIN, storage: testStorage() });
+
+    const client = fakeClient();
+    request(client);
+    expect(await reply(client)).toMatchObject({ error: 'denied' });
+  });
+
+  it('names the canister by query parameter against a local replica', async () => {
+    const fetchMock = record([CLIENT_ORIGIN]);
+    vi.stubGlobal('fetch', fetchMock);
+    stop = serveSharedSession({
+      derivationOrigin: `http://${CANISTER_ID}.localhost:4943`,
+      storage: testStorage(),
+    });
+
+    const client = fakeClient();
+    request(client);
+    await reply(client);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://${CANISTER_ID}.localhost:4943/.well-known/ii-alternative-origins?canisterId=${CANISTER_ID}`,
+      expect.anything(),
+    );
   });
 
   it('denies everyone when the record lists more origins than II accepts', async () => {
@@ -294,7 +322,6 @@ describe('serveSharedSession allow-list discovery', () => {
     );
     stop = serveSharedSession({
       derivationOrigin: DERIVATION_ORIGIN,
-      canisterId: CANISTER_ID,
       storage: testStorage(),
     });
 
@@ -307,7 +334,6 @@ describe('serveSharedSession allow-list discovery', () => {
     vi.stubGlobal('fetch', record('https://a.example.com'));
     stop = serveSharedSession({
       derivationOrigin: DERIVATION_ORIGIN,
-      canisterId: CANISTER_ID,
       storage: testStorage(),
     });
 

--- a/tests/shared-session/storage.test.ts
+++ b/tests/shared-session/storage.test.ts
@@ -4,10 +4,8 @@ import { SharedSessionStorage } from '../../src/shared-session/storage.ts';
 
 const HUB_URL = 'https://auth.example.com/hub.html';
 const HUB_ORIGIN = 'https://auth.example.com';
-const DERIVATION_ORIGIN = 'https://example.com';
 
-const testStorage = (timeout = 500) =>
-  new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN, timeout });
+const testStorage = (timeout = 500) => new SharedSessionStorage({ url: HUB_URL, timeout });
 
 /**
  * Stands in for the hub page. jsdom leaves an iframe on `about:blank` because
@@ -58,18 +56,12 @@ describe('SharedSessionStorage', () => {
     ['a relative url', '/hub.html', 'must be an absolute URL'],
     ['plain http', 'http://auth.example.com/hub.html', 'must be served over https'],
   ])('rejects %s for the hub', (_label, url, message) => {
-    expect(() => new SharedSessionStorage({ url, derivationOrigin: DERIVATION_ORIGIN })).toThrow(
-      message,
-    );
+    expect(() => new SharedSessionStorage({ url })).toThrow(message);
   });
 
   it('accepts a loopback hub for local development', () => {
     expect(
-      () =>
-        new SharedSessionStorage({
-          url: 'http://localhost:5174/shared-session.html',
-          derivationOrigin: 'http://localhost:5173',
-        }),
+      () => new SharedSessionStorage({ url: 'http://localhost:5174/shared-session.html' }),
     ).not.toThrow();
   });
 
@@ -86,7 +78,6 @@ describe('SharedSessionStorage', () => {
       type: CHANNEL,
       op: 'get',
       key: 'identity',
-      derivationOrigin: DERIVATION_ORIGIN,
     });
     expect(post).toHaveBeenCalledWith(expect.anything(), HUB_ORIGIN);
     expect(await pending).toBe('stored-key');

--- a/tests/shared-session/storage.test.ts
+++ b/tests/shared-session/storage.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CHANNEL, PROTOCOL_VERSION } from '../../src/shared-session/protocol.ts';
+import { SharedSessionStorage } from '../../src/shared-session/storage.ts';
+
+const HUB_URL = 'https://auth.example.com/hub.html';
+const HUB_ORIGIN = 'https://auth.example.com';
+const DERIVATION_ORIGIN = 'https://example.com';
+
+const testStorage = (timeout = 500) =>
+  new SharedSessionStorage({
+    hub: { url: HUB_URL, timeout },
+    derivationOrigin: DERIVATION_ORIGIN,
+  });
+
+/**
+ * Stands in for the hub page. jsdom leaves an iframe on `about:blank` because
+ * subresources are not loaded, so its window is a usable postMessage target.
+ */
+async function hub() {
+  const frame = await vi.waitFor(() => {
+    const found = document.querySelector('iframe');
+    expect(found).not.toBeNull();
+    return found as HTMLIFrameElement;
+  });
+  const window = frame.contentWindow;
+  if (window === null) throw new Error('iframe has no content window');
+  const post = vi.spyOn(window, 'postMessage');
+
+  const send = (data: unknown, source: unknown = window) => {
+    const event = new MessageEvent('message', { origin: HUB_ORIGIN, data });
+    // `source` is a prototype accessor, so it can only be supplied this way.
+    Object.defineProperty(event, 'source', { value: source });
+    globalThis.dispatchEvent(event);
+  };
+
+  return {
+    frame,
+    post,
+    send,
+    ready: (v = PROTOCOL_VERSION) => send({ v, type: CHANNEL, ready: true }),
+    /** Answers the client's nth request, defaulting to the first. */
+    answer: async (body: Record<string, unknown>, nth = 0) => {
+      await vi.waitFor(() => expect(post.mock.calls.length).toBeGreaterThan(nth));
+      const request = post.mock.calls[nth][0] as { id: number };
+      send({ v: PROTOCOL_VERSION, type: CHANNEL, id: request.id, ...body });
+      return request;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  for (const frame of document.querySelectorAll('iframe')) frame.remove();
+});
+
+describe('SharedSessionStorage', () => {
+  it.each([
+    ['a relative url', '/hub.html', 'must be an absolute URL'],
+    ['plain http', 'http://auth.example.com/hub.html', 'must be served over https'],
+  ])('rejects %s for the hub', (_label, url, message) => {
+    expect(
+      () => new SharedSessionStorage({ hub: { url }, derivationOrigin: DERIVATION_ORIGIN }),
+    ).toThrow(message);
+  });
+
+  it('accepts a loopback hub for local development', () => {
+    expect(
+      () =>
+        new SharedSessionStorage({
+          hub: { url: 'http://localhost:5174/hub.html' },
+          derivationOrigin: 'http://localhost:5173',
+        }),
+    ).not.toThrow();
+  });
+
+  it('reads through the hub once it announces itself', async () => {
+    const storage = testStorage();
+    const pending = storage.get('identity');
+    const { post, ready, answer } = await hub();
+
+    ready();
+    const request = await answer({ result: 'stored-key' });
+
+    expect(request).toMatchObject({
+      v: PROTOCOL_VERSION,
+      type: CHANNEL,
+      op: 'get',
+      key: 'identity',
+      derivationOrigin: DERIVATION_ORIGIN,
+    });
+    expect(post).toHaveBeenCalledWith(expect.anything(), HUB_ORIGIN);
+    expect(await pending).toBe('stored-key');
+  });
+
+  it('writes and removes through the hub', async () => {
+    const storage = testStorage();
+    const written = storage.set('identity', 'written');
+    const { ready, answer } = await hub();
+    ready();
+
+    expect(await answer({ result: null })).toMatchObject({ op: 'set', value: 'written' });
+    await expect(written).resolves.toBeUndefined();
+
+    const removed = storage.remove('identity');
+    expect(await answer({ result: null }, 1)).toMatchObject({ op: 'remove' });
+    await expect(removed).resolves.toBeUndefined();
+  });
+
+  it('reports a missing value as null', async () => {
+    const storage = testStorage();
+    const pending = storage.get('identity');
+    const { ready, answer } = await hub();
+
+    ready();
+    await answer({ result: null });
+
+    expect(await pending).toBeNull();
+  });
+
+  it('reuses one hub connection across operations', async () => {
+    const storage = testStorage();
+    const first = storage.get('identity');
+    const { ready, answer } = await hub();
+    ready();
+    await answer({ result: 'a' });
+    expect(await first).toBe('a');
+
+    const second = storage.get('delegation');
+    await answer({ result: 'b' }, 1);
+    expect(await second).toBe('b');
+
+    expect(document.querySelectorAll('iframe')).toHaveLength(1);
+  });
+
+  it('surfaces an error reply from the hub', async () => {
+    const storage = testStorage();
+    const pending = storage.get('identity');
+    const { ready, answer } = await hub();
+
+    ready();
+    await answer({ error: 'denied' });
+
+    await expect(pending).rejects.toThrow('Shared session hub refused get: denied');
+  });
+
+  it('names the hub url when it never answers', async () => {
+    const storage = testStorage(20);
+
+    await expect(storage.get('identity')).rejects.toThrow(
+      `Shared session hub at ${HUB_URL} did not respond within 20ms`,
+    );
+  });
+
+  it('refuses a hub speaking a different protocol version', async () => {
+    const storage = testStorage();
+    const pending = storage.get('identity');
+    const { ready } = await hub();
+
+    ready(PROTOCOL_VERSION + 1);
+
+    await expect(pending).rejects.toThrow(
+      `speaks protocol version ${PROTOCOL_VERSION + 1}, this client speaks ${PROTOCOL_VERSION}`,
+    );
+  });
+
+  it('ignores an announcement from another frame on the hub origin', async () => {
+    const storage = testStorage(50);
+    const pending = storage.get('identity');
+    const { send } = await hub();
+
+    send({ v: PROTOCOL_VERSION, type: CHANNEL, ready: true }, { name: 'another frame' });
+
+    await expect(pending).rejects.toThrow('did not respond within');
+  });
+
+  it('removes the frame and retries after a failed connection', async () => {
+    const storage = testStorage();
+    const failed = storage.get('identity');
+    const rejected = await hub();
+    rejected.ready(PROTOCOL_VERSION + 1);
+
+    await expect(failed).rejects.toThrow('speaks protocol version');
+    expect(document.querySelectorAll('iframe')).toHaveLength(0);
+
+    const retried = storage.get('identity');
+    const retry = await hub();
+    retry.ready();
+    await retry.answer({ result: 'after-retry' });
+
+    expect(await retried).toBe('after-retry');
+    expect(document.querySelectorAll('iframe')).toHaveLength(1);
+  });
+});

--- a/tests/shared-session/storage.test.ts
+++ b/tests/shared-session/storage.test.ts
@@ -7,10 +7,7 @@ const HUB_ORIGIN = 'https://auth.example.com';
 const DERIVATION_ORIGIN = 'https://example.com';
 
 const testStorage = (timeout = 500) =>
-  new SharedSessionStorage({
-    hub: { url: HUB_URL, timeout },
-    derivationOrigin: DERIVATION_ORIGIN,
-  });
+  new SharedSessionStorage({ url: HUB_URL, derivationOrigin: DERIVATION_ORIGIN, timeout });
 
 /**
  * Stands in for the hub page. jsdom leaves an iframe on `about:blank` because
@@ -61,16 +58,16 @@ describe('SharedSessionStorage', () => {
     ['a relative url', '/hub.html', 'must be an absolute URL'],
     ['plain http', 'http://auth.example.com/hub.html', 'must be served over https'],
   ])('rejects %s for the hub', (_label, url, message) => {
-    expect(
-      () => new SharedSessionStorage({ hub: { url }, derivationOrigin: DERIVATION_ORIGIN }),
-    ).toThrow(message);
+    expect(() => new SharedSessionStorage({ url, derivationOrigin: DERIVATION_ORIGIN })).toThrow(
+      message,
+    );
   });
 
   it('accepts a loopback hub for local development', () => {
     expect(
       () =>
         new SharedSessionStorage({
-          hub: { url: 'http://localhost:5174/hub.html' },
+          url: 'http://localhost:5174/shared-session.html',
           derivationOrigin: 'http://localhost:5173',
         }),
     ).not.toThrow();


### PR DESCRIPTION
## Problem

A session belongs to the origin it was created on, so an application served from `docs.example.com` and `chat.example.com` asks the user to sign in twice and gives each origin a different principal.

A cross-subdomain cookie would share it, but it rides along on every request to the domain, is readable by any script on it, and cannot hold the default non-extractable `CryptoKeyPair`.

## Approach

Sharing a session is a storage concern, so this adds storage backends rather than new sign-in options:

```ts
// a page on any origin you control
serveSharedSession({ derivationOrigin: 'https://auth.example.com' });

// every consuming origin
new AuthClient({
  storage: new SharedSessionStorage({ url: 'https://auth.example.com/shared-session.html' }),
  syncStorage: new SyncCookieStorage({ domain: 'example.com' }),
  derivationOrigin: 'https://auth.example.com',
});
```

`SharedSessionStorage` keeps the session on the hub page's origin and proxies `get`/`set`/`remove` to it over `postMessage`. Nothing is stored on the consuming origins and no credential enters an HTTP header.

Which origins may read it is the derivation origin's `.well-known/ii-alternative-origins` record — the same record Internet Identity reads when deriving a principal for an alternative origin. Reusing it is deliberate: every origin listed there can already obtain a delegation for that principal by signing in with `derivationOrigin` set, so serving a stored session to exactly that set grants no further authority, and there is one list to maintain instead of two that can drift.

`SyncCookieStorage` backs `isAuthenticated()`, which is synchronous and so cannot read the shared session. It holds one non-secret value — the delegation's expiration, with `Max-Age` to match — and is a hint, not authority: any subdomain can write it, but the identity is still read from the shared session and verified, so a forged value causes a wrong render, not an authentication.

## Notes for review

- **New entry point** `@icp-sdk/auth/shared-session`, so app bundles don't carry the hub and hub pages don't carry `AuthClient`.
- **`AuthClientCreateOptions` stays a plain interface**; the only addition is `syncStorage`. An earlier revision added a `sharedSessionHub` option that required making it a union — dropped in favour of setting `storage` directly.
- **Versioned wire protocol**, checked on both sides, since hub and clients are separate deploys. Messages without an `id` are reserved for hub-initiated pushes, so a client meeting a future invalidation ignores it rather than failing to parse it. Live invalidation is not implemented; the docs already say another origin may end the session, so adding it later isn't breaking.
- **Allow-list reads** go through `<canisterId>.icp0.io`, where a boundary node verifies certification — the same precaution `validateDerivationOrigin` takes in the II frontend. The canister id is resolved rather than configured, mirroring II's `resolveCanisterId`: leftmost label on a well-known IC domain, otherwise the `x-ic-canister-id` header from a `HEAD` of the origin, with a local replica addressed by query parameter. Same-origin when the hub happens to own the derivation origin. That header is uncertified, so a party able to tamper with an origin's responses can name a canister of their own — II inherits the same limit, and it is documented on the resolver. Discovery failures deny every client and are not cached.
- **Input guards**: bare-`https`-origin parsing for record entries (path, port, trailing slash, or credentials rejected), `redirect: 'error'`, `credentials: 'omit'`, II's 10-entry cap, and `event.source` verification on the handshake so another frame on the hub's origin cannot answer for it.
- **Two deliberate gaps**, both documented: nothing checks that a client's `derivationOrigin` matches the hub's, and the cookie assumes one shared session per domain. Earlier revisions enforced both; the options they needed weren't worth keeping a third and fourth copy of the same value in sync.
- Two `biome-ignore`s for `noDocumentCookie` — the rule suggests the Cookie Store API, which is async, the opposite of what that store is for.
- Cross-registrable-domain sharing is out of scope: that storage is partitioned in all engines, so an off-domain record entry reads an empty store rather than leaking.
## Two fixes this exposed

Both also affect the existing IndexedDB path:

1. **`isAuthenticated()` reported no session on an origin sharing one.** It reads an expiration cache that only `persistChain` wrote, so an origin that restored a session but never signed in had nothing cached. Now written on restore and cleared when the store proves empty — which also settles the pre-existing case of storage cleared behind the client's back, where it returned `true` while `getIdentity()` was anonymous.

2. **A storage read failure produced an unhandled rejection.** `restoreKey` awaits `storage.get` outside its try/catch, so a failure rejected the hydration promise the constructor starts without awaiting, leaving `getIdentity()` rejecting for the page's lifetime. Unreachable storage is routine for a store on another origin, so hydration now absorbs it, logs, and stays anonymous — without clearing the cached expiration, since a hub that failed to answer has not said the session is gone.

## Testing

`pnpm test` — 147 passing, no type errors; `pnpm build`, `publint --strict` and `biome check` clean.

Hub tests drive the real `serveSharedSession` listener with synthesized `MessageEvent`s; client tests drive the real class against a stand-in hub window, covering the handshake, version mismatch, denial, timeouts naming the resolved URL, and frame cleanup on a failed connection. Cookie tests assert the attributes (`Domain`, `SameSite`, `Secure`, `Max-Age`), which `document.cookie` cannot read back, by capturing writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



